### PR TITLE
ci: 自动化正式发布流程

### DIFF
--- a/.agent/notes.md
+++ b/.agent/notes.md
@@ -75,14 +75,14 @@ CI 用 `.venv-ci`，本地打包用 `pack_venv`。`build.py` 中 babel locale-da
 - **babel locale-data**：自定义 hook（`pyinstaller-hooks/hook-babel.py`）排除全部 1086 个 locale .dat，按需添加 9 个（zh/en 系列）
 - **排除模块**：保留 `scipy`、`lxml.objectify` 等无运行期入口模块；`pandas` 不再是直接打包依赖，Excel 导出保持 `openpyxl` 直写；`numpy`/`numpy.libs` 仅为 openpyxl 可选支持和环境残留，打包时应排除；**不要排除** `sqlite3`（DataRecorder/DrissionPage 顶层依赖）、`lxml.html`（DrissionPage 顶层依赖）
 - **体积判断**：Windows `--onefile` 单文件 EXE 通常比 macOS `--onedir` 后的 ZIP/DMG 大；不要用 macOS 32MB 反推 Windows。当前 Windows EXE 约 36.4MB、macOS ZIP/DMG 约 31-33MB 属正常范围
-- **CI 跨平台重建**：`build.py`、`pyinstaller-hooks/` 和核心源码/配置变更会触发对端平台 CI 重建；macOS 对端产物必须同时有 ZIP 和 DMG
+- **CI 双平台构建**：首次发布并行构建 Windows 和 macOS；断点续跑仅在附件完整时复用，macOS 必须同时有 ZIP 和 DMG
 
 ## Gitee Release 上传与校验
 
-- GitHub CI 只上传 GitHub Release；本地发布机将 CI 对端产物下载后同步 Gitee
-- macOS ZIP/DMG 使用最多 2 路并发流水传输，小文件最多 3 路并发；上传/下载超时 600s，4xx 不重试
+- GitHub Actions 的 Windows 发布任务集中下载 Windows/macOS 产物，按 EXE→ZIP→DMG 串行镜像到 Gitee；任一失败立即停止
+- 上传前比较远端附件和产物，同一提交断点续跑时复用已验证附件；上传/下载超时 600s，4xx 不重试
 - 发布主流程只校验附件齐全和 size 与 GitHub 一致，不回下载大文件；需要逐文件 SHA256 时手动运行 `python build.py --verify-gitee-integrity X.Y.Z`
-- **Gitee Token**：本地使用环境变量 `GITEE_TOKEN`；GitHub Repository Secret 不参与当前发布流程
+- **Gitee Token**：正式发布使用 Actions Repository Secret `GITEE_TOKEN`；本地手工核验/补传使用同名环境变量
 
 ## API / BOSS Page
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,129 +1,204 @@
 name: Build & Release
+run-name: Release v${{ inputs.version }}${{ inputs.dry_run && ' (Dry Run)' || '' }}
 
 on:
   workflow_dispatch:
     inputs:
-      platform:
-        description: 'Target platform: all, macos, or windows'
-        required: false
-        default: 'all'
-        type: choice
-        options:
-          - all
-          - macos
-          - windows
-      tag:
-        description: 'Release tag (e.g. v2.11.2). Required when triggered manually.'
-        required: false
+      version:
+        description: "Version without v prefix, for example 2.21"
+        required: true
         type: string
+      authorization:
+        description: "Exact authorization text: 正式发布 vX.Y"
+        required: true
+        type: string
+      dry_run:
+        description: "Run the strict gate only; do not build, tag, push, or publish"
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: write
 
+env:
+  PYTHONIOENCODING: utf-8
+  PYTHONUTF8: "1"
+
+concurrency:
+  group: formal-release-${{ inputs.version }}
+  cancel-in-progress: false
+  queue: max
+
 jobs:
-  check:
-    runs-on: ubuntu-latest
+  prepare:
+    name: Strict release gate
+    runs-on: windows-latest
+    timeout-minutes: 30
     outputs:
-      needs: ${{ steps.check.outputs.needs }}
-    steps:
-      - name: Check existing release assets
-        id: check
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
-          PLATFORM="${{ inputs.platform || 'all' }}"
-          needs='[]'
-
-          assets=$(gh api "repos/${{ github.repository }}/releases/tags/$TAG" \
-                   --jq '.assets[].name' 2>/dev/null || true)
-
-          if [[ "$PLATFORM" == "all" || "$PLATFORM" == "windows" ]]; then
-            if ! echo "$assets" | grep -q '^BOSS_ResumeFilter\.exe$'; then
-              needs=$(echo "$needs" | jq -c '. + [{"os":"windows-latest","platform":"windows"}]')
-            fi
-          fi
-
-          if [[ "$PLATFORM" == "all" || "$PLATFORM" == "macos" ]]; then
-            if ! echo "$assets" | grep -q '^BOSS_ResumeFilter_mac\.zip$' || \
-               ! echo "$assets" | grep -q '^BOSS_ResumeFilter\.dmg$'; then
-              needs=$(echo "$needs" | jq -c '. + [{"os":"macos-latest","platform":"macos"}]')
-            fi
-          fi
-
-          echo "needs=$needs" >> "$GITHUB_OUTPUT"
-          echo "Will build: $needs"
-
-  build:
-    needs: check
-    if: needs.check.outputs.needs != '[]'
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.check.outputs.needs) }}
-
-    runs-on: ${{ matrix.os }}
+      version: ${{ steps.prepare.outputs.version }}
+      tag: ${{ steps.prepare.outputs.tag }}
+      release_sha: ${{ steps.prepare.outputs.release_sha }}
+      resume: ${{ steps.prepare.outputs.resume }}
+      needs_windows: ${{ steps.prepare.outputs.needs_windows }}
+      needs_macos: ${{ steps.prepare.outputs.needs_macos }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Checkout master
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
 
-      - name: Set UTF-8 encoding
-        shell: bash
-        run: |
-          echo "PYTHONIOENCODING=utf-8" >> $GITHUB_ENV
-          echo "PYTHONUTF8=1" >> $GITHUB_ENV
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
 
-      - name: Cache virtual environment
-        uses: actions/cache@v4
-        id: venv-cache
-        with:
-          path: .venv-ci
-          key: venv-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
-
-      - name: Install dependencies (only on cache miss)
-        if: steps.venv-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          python -m venv .venv-ci
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            .venv-ci/Scripts/pip install -r requirements.txt pyinstaller
-          else
-            .venv-ci/bin/pip install -r requirements.txt pyinstaller dmgbuild
-          fi
-
-      - name: Verify tkinter
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            .venv-ci/Scripts/python -c "import tkinter; print('tkinter OK:', tkinter.TkVersion)"
-          else
-            .venv-ci/bin/python -c "import tkinter; print('tkinter OK:', tkinter.TkVersion)"
-          fi
-
-      - name: Build
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            .venv-ci/Scripts/python build.py --ci --release
-          else
-            .venv-ci/bin/python build.py --ci --release
-          fi
+      - name: Validate authorization and run strict gate
+        id: prepare
         env:
-          PYTHONIOENCODING: utf-8
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_DRY_RUN: ${{ inputs.dry_run }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_AUTHORIZATION: ${{ inputs.authorization }}
+        run: >-
+          python scripts/release_ci.py prepare
+          --version "$env:RELEASE_VERSION"
+          --authorization "$env:RELEASE_AUTHORIZATION"
+          --github-output "$env:GITHUB_OUTPUT"
 
-      - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@v2
+  build_windows:
+    name: Build Windows artifact
+    needs: prepare
+    if: ${{ inputs.dry_run == false && needs.prepare.outputs.needs_windows == 'true' }}
+    runs-on: windows-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout immutable release commit
+        uses: actions/checkout@v6
         with:
-          tag_name: ${{ inputs.tag || github.ref_name }}
-          files: |
-            dist/BOSS_ResumeFilter.exe
-            dist/BOSS_ResumeFilter.dmg
+          ref: ${{ needs.prepare.outputs.release_sha }}
+          fetch-depth: 0
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install build dependencies
+        run: python -m pip install -r requirements.txt pyinstaller
+
+      - name: Build and verify Windows package
+        run: python build.py --ci --release --strict-changelog
+
+      - name: Upload Windows workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-release
+          path: dist/BOSS_ResumeFilter.exe
+          if-no-files-found: error
+          retention-days: 7
+
+  build_macos:
+    name: Build macOS artifacts
+    needs: prepare
+    if: ${{ inputs.dry_run == false && needs.prepare.outputs.needs_macos == 'true' }}
+    runs-on: macos-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout immutable release commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.release_sha }}
+          fetch-depth: 0
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install build dependencies
+        run: python -m pip install -r requirements.txt pyinstaller dmgbuild
+
+      - name: Build and verify macOS packages
+        run: python build.py --ci --release --strict-changelog
+
+      - name: Upload macOS workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-release
+          path: |
             dist/BOSS_ResumeFilter_mac.zip
+            dist/BOSS_ResumeFilter.dmg
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish, mirror, and verify
+    needs: [prepare, build_windows, build_macos]
+    if: >-
+      ${{
+        inputs.dry_run == false &&
+        always() &&
+        needs.prepare.result == 'success' &&
+        (needs.build_windows.result == 'success' || needs.build_windows.result == 'skipped') &&
+        (needs.build_macos.result == 'success' || needs.build_macos.result == 'skipped')
+      }}
+    runs-on: windows-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout immutable release commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.release_sha }}
+          fetch-depth: 0
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install publishing dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Download Windows workflow artifact
+        if: ${{ needs.prepare.outputs.needs_windows == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-release
+          path: dist
+
+      - name: Download macOS workflow artifacts
+        if: ${{ needs.prepare.outputs.needs_macos == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-release
+          path: dist
+
+      - name: Publish both remotes and run online acceptance
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+          RELEASE_AUTHORIZATION: ${{ inputs.authorization }}
+          RELEASE_SHA: ${{ needs.prepare.outputs.release_sha }}
+        run: >-
+          python scripts/release_ci.py publish
+          --version "$env:RELEASE_VERSION"
+          --authorization "$env:RELEASE_AUTHORIZATION"
+          --release-sha "$env:RELEASE_SHA"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,13 +33,14 @@ boss-resume-filter/
 ├── paths.py              # 路径工具（get_base_dir、ensure_config_files、路径常量）
 ├── build.py              # PyInstaller 打包脚本（支持 --release 一键发布）
 ├── build_education_tool.py # 独立学历证书核验助手打包脚本
-├── latest.json           # 版本清单（Gitee 更新源，build.py --release 自动维护）
+├── latest.json           # 双源版本清单（正式发布工作流自动维护）
 ├── job_config.json       # 岗位筛选规则配置
 ├── api_config.json       # 发布默认 AI 模型配置模板（不含明文 Key）
 ├── selectors.json        # 页面选择器配置（CSS/XPath/关键词，DOM 变化时修改）
 ├── ui_config.json        # UI 尺寸与缩放配置
 ├── tests/                # 测试脚本目录
 ├── scripts/              # 辅助脚本（发布监控、PPT 生成、截图等）
+│   ├── release_ci.py   # GitHub Actions 正式发布编排与线上验收
 │   └── watch_progress.py # 发布进度监控脚本（轮询 .build_progress.json）
 ├── pyinstaller-hooks/    # PyInstaller 自定义 hook（控制模块收集范围，减小产物体积）
 ├── GUI 使用说明.md       # 图形界面操作说明
@@ -76,9 +77,9 @@ boss-resume-filter/
 ### 开发与交付流程
 
 - 低风险文档、测试和局部文案可在当前工作区修改；普通代码任务使用 `codex/<task>` 短期分支，并行、脏工作区、长周期或高风险任务才创建独立 worktree
-- PR 不作统一要求；核心筛选、自动打招呼、存储、更新器、发布脚本、CI/CD 或大范围修改应使用 PR；面向 `master` 的 PR 由 `PR Checks` 自动执行源码编译、稳定回归和导入烟测，合并 `master` 不等于正式发布
-- 推送、公开发布、删除分支/worktree/临时文件须分别获得用户授权
-- 发布前执行 `/neat-freak`、严格发布门禁和风险相关实测；发布后核验公开下载、自动更新及本次核心链路
+- PR 不作统一要求；核心筛选、自动打招呼、存储、更新器、发布脚本、CI/CD 或大范围修改应使用 PR；面向 `master` 的 PR 由 `PR Checks` 验证，PR 合并始终是独立授权，合并不会触发发布
+- 普通分支推送、PR 合并、删除分支/worktree/临时文件须分别获得用户授权；用户明确说“正式发布 vX.Y”后，该一次授权覆盖 `Build & Release` 内部的严格门禁、tag/清单推送、GitHub/Gitee Release 和线上验收，不再逐步确认
+- 发布准备 PR 合并前执行 `/neat-freak`、文案润色和风险相关实测；授权后由工作流重跑严格门禁并核验公开下载、自动更新和双远端状态
 - 已公开 tag 不得移动或覆盖，修复必须发布更高补丁版本；同一提交允许断点续跑
 - `candidates_all.json`、本地 API 配置、Chrome profile 和登录状态不属于任务临时文件，禁止收尾时自动清理
 
@@ -106,12 +107,12 @@ boss-resume-filter/
 - `python build.py --check [--strict-changelog]`：仅发布前检查；严格模式将 CHANGELOG 启发式覆盖、README 逐条镜像和 latest.json 同步提示升级为硬失败
 - `python build.py --sync-release-notes`：修正 CHANGELOG 后同步 GitHub + Gitee Release 说明，不重新打包
 - `python build.py`：自动打包（Windows EXE / macOS .app+ZIP+DMG），`IS_MAC`/`IS_WIN` 自动检测
-- `python build.py --release [--auto] [--version X.Y]`：打包→提交→tag→推送确认→GitHub Release 上传→Gitee 同步
+- `gh workflow run release.yml --ref master -f version=X.Y -f authorization="正式发布 vX.Y" -f dry_run=false`：唯一正式发布入口；严格门禁→双平台构建→双 Release→latest.json→线上验收
 - `python build.py --verify-release X.Y.Z`：只读核验双远端分支/tag、GitHub/Gitee Release、附件完整性和 latest.json，不打包不推送
 - 发布前必须执行 `/neat-freak` 并润色 CHANGELOG 当前版本段落；`gui_main.py` 的 `__version__` 是唯一版本号来源
 - `.build_state.json` 指纹未变时复用产物，`--force-build` 强制重建；Windows 使用 `--onefile --noconsole`，macOS 使用 `--onedir --windowed`
 - `_preflight_checks()` 验证依赖、敏感文件、源码编译、文档同步和回归测试；依赖变更须同步 `build.py:REQUIRED_IMPORTS`
-- Release 模式只自动提交 `--version` 引起的版本号变化，其他变更须先手工提交；推送前 `input()` 确认 [y/N]，同名 tag 仅在指向当前提交时允许续跑，任何冲突都中止且不得自动 `--force`
+- 本地 `build.py --release` 已停用，`--ci --release` 仅供 Actions 构建任务使用；同名 tag 只能在指向同一发布提交时断点续跑，不得移动或 `--force`
 - CHANGELOG 硬门禁包括当前版本、分类顺序、README 入口、历史完整性、源码编译和回归测试；正反向覆盖等启发式检查默认提示、严格模式阻断
 
 #### 打包体积优化（当前 Windows 约 36.4MB，macOS ZIP/DMG 约 31-33MB）
@@ -121,7 +122,7 @@ boss-resume-filter/
 - **排除模块**：保留 `scipy`、`lxml.objectify` 等无运行期入口模块；`pandas` 不再是直接打包依赖，Excel 导出保持 `openpyxl` 直写；`numpy`/`numpy.libs` 仅为 openpyxl 可选支持和环境残留，打包时应排除；**不要排除** `sqlite3`（DataRecorder/DrissionPage 顶层依赖）、`lxml.html`（DrissionPage 顶层依赖）
 - **体积判断**：Windows 使用 `--onefile` 单文件 EXE，通常比 macOS `--onedir` 后的 ZIP/DMG 大；不要用 macOS 32MB 反推 Windows 也必须接近 32MB。当前 Windows EXE 约 36.4MB、macOS ZIP/DMG 约 31-33MB 属正常范围。
 - 修改 build.py 时注意保持上述优化，避免体积回退
-- **CI 跨平台重建**：`build.py`、`pyinstaller-hooks/` 和核心源码/配置变更会触发对端平台 CI 重建；macOS 对端产物必须同时有 ZIP 和 DMG，否则 CI 需重建
+- **CI 双平台构建**：首次发布并行构建 Windows 和 macOS；断点续跑仅在附件完整性可验证时复用，macOS 必须同时有 ZIP 和 DMG
 
 ## 代码规范
 
@@ -311,9 +312,9 @@ API 兜底翻页连续 3 页无 DOM 命中时提前停止，避免无效请求�
 - **Windows**：下载 EXE → 校验 SHA256 → `update.bat` 替换重启；脚本须清理 `_PYI_*` 环境变量 + `PYINSTALLER_RESET_ENVIRONMENT=1` 防 DLL 缺失
 - **macOS**：.app 运行→下载 ZIP 替换重启；源码→`git pull`
 - `latest.json` 的 `assets` 记录产物 `size`/`sha256` 供校验
-- **Gitee Release 上传**：GitHub CI 只上传 GitHub Release；本地发布机将 CI 对端产物下载后同步 Gitee。macOS ZIP/DMG 使用最多 2 路并发流水传输，小文件最多 3 路并发；上传/下载超时 600s，4xx 不重试
+- **Gitee Release 上传**：`Build & Release` 的 Windows 发布任务集中下载双平台产物，按 EXE→ZIP→DMG 串行镜像到 Gitee；任一附件失败立即中止，重跑时复用已验证附件
 - **Gitee 完整性校验**：发布主流程只校验附件齐全和 size 与 GitHub 一致，不回下载大文件；需要逐文件 SHA256 时手动运行 `python build.py --verify-gitee-integrity X.Y.Z`
-- **Gitee Token**：本地使用环境变量 `GITEE_TOKEN`；GitHub Repository Secret 不参与当前发布流程
+- **Gitee Token**：Actions 使用 Repository Secret `GITEE_TOKEN`（需 projects 权限）；本地手工核验/补传仍使用同名环境变量
 ## 低频专项说明
 
 低频踩坑、平台差异和专项背景放在 `.agent/notes.md`。这是项目级稳定说明，可以进 git；不要把会话记忆、临时调试日志或自动生成的 agent 记忆放进去。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,13 +33,14 @@ boss-resume-filter/
 ├── paths.py              # 路径工具（get_base_dir、ensure_config_files、路径常量）
 ├── build.py              # PyInstaller 打包脚本（支持 --release 一键发布）
 ├── build_education_tool.py # 独立学历证书核验助手打包脚本
-├── latest.json           # 版本清单（Gitee 更新源，build.py --release 自动维护）
+├── latest.json           # 双源版本清单（正式发布工作流自动维护）
 ├── job_config.json       # 岗位筛选规则配置
 ├── api_config.json       # 发布默认 AI 模型配置模板（不含明文 Key）
 ├── selectors.json        # 页面选择器配置（CSS/XPath/关键词，DOM 变化时修改）
 ├── ui_config.json        # UI 尺寸与缩放配置
 ├── tests/                # 测试脚本目录
 ├── scripts/              # 辅助脚本（发布监控、PPT 生成、截图等）
+│   ├── release_ci.py   # GitHub Actions 正式发布编排与线上验收
 │   └── watch_progress.py # 发布进度监控脚本（轮询 .build_progress.json）
 ├── pyinstaller-hooks/    # PyInstaller 自定义 hook（控制模块收集范围，减小产物体积）
 ├── GUI 使用说明.md       # 图形界面操作说明
@@ -76,9 +77,9 @@ boss-resume-filter/
 ### 开发与交付流程
 
 - 低风险文档、测试和局部文案可在当前工作区修改；普通代码任务使用 `codex/<task>` 短期分支，并行、脏工作区、长周期或高风险任务才创建独立 worktree
-- PR 不作统一要求；核心筛选、自动打招呼、存储、更新器、发布脚本、CI/CD 或大范围修改应使用 PR；面向 `master` 的 PR 由 `PR Checks` 自动执行源码编译、稳定回归和导入烟测，合并 `master` 不等于正式发布
-- 推送、公开发布、删除分支/worktree/临时文件须分别获得用户授权
-- 发布前执行 `/neat-freak`、严格发布门禁和风险相关实测；发布后核验公开下载、自动更新及本次核心链路
+- PR 不作统一要求；核心筛选、自动打招呼、存储、更新器、发布脚本、CI/CD 或大范围修改应使用 PR；面向 `master` 的 PR 由 `PR Checks` 验证，PR 合并始终是独立授权，合并不会触发发布
+- 普通分支推送、PR 合并、删除分支/worktree/临时文件须分别获得用户授权；用户明确说“正式发布 vX.Y”后，该一次授权覆盖 `Build & Release` 内部的严格门禁、tag/清单推送、GitHub/Gitee Release 和线上验收，不再逐步确认
+- 发布准备 PR 合并前执行 `/neat-freak`、文案润色和风险相关实测；授权后由工作流重跑严格门禁并核验公开下载、自动更新和双远端状态
 - 已公开 tag 不得移动或覆盖，修复必须发布更高补丁版本；同一提交允许断点续跑
 - `candidates_all.json`、本地 API 配置、Chrome profile 和登录状态不属于任务临时文件，禁止收尾时自动清理
 
@@ -106,12 +107,12 @@ boss-resume-filter/
 - `python build.py --check [--strict-changelog]`：仅发布前检查；严格模式将 CHANGELOG 启发式覆盖、README 逐条镜像和 latest.json 同步提示升级为硬失败
 - `python build.py --sync-release-notes`：修正 CHANGELOG 后同步 GitHub + Gitee Release 说明，不重新打包
 - `python build.py`：自动打包（Windows EXE / macOS .app+ZIP+DMG），`IS_MAC`/`IS_WIN` 自动检测
-- `python build.py --release [--auto] [--version X.Y]`：打包→提交→tag→推送确认→GitHub Release 上传→Gitee 同步
+- `gh workflow run release.yml --ref master -f version=X.Y -f authorization="正式发布 vX.Y" -f dry_run=false`：唯一正式发布入口；严格门禁→双平台构建→双 Release→latest.json→线上验收
 - `python build.py --verify-release X.Y.Z`：只读核验双远端分支/tag、GitHub/Gitee Release、附件完整性和 latest.json，不打包不推送
 - 发布前必须执行 `/neat-freak` 并润色 CHANGELOG 当前版本段落；`gui_main.py` 的 `__version__` 是唯一版本号来源
 - `.build_state.json` 指纹未变时复用产物，`--force-build` 强制重建；Windows 使用 `--onefile --noconsole`，macOS 使用 `--onedir --windowed`
 - `_preflight_checks()` 验证依赖、敏感文件、源码编译、文档同步和回归测试；依赖变更须同步 `build.py:REQUIRED_IMPORTS`
-- Release 模式只自动提交 `--version` 引起的版本号变化，其他变更须先手工提交；推送前 `input()` 确认 [y/N]，同名 tag 仅在指向当前提交时允许续跑，任何冲突都中止且不得自动 `--force`
+- 本地 `build.py --release` 已停用，`--ci --release` 仅供 Actions 构建任务使用；同名 tag 只能在指向同一发布提交时断点续跑，不得移动或 `--force`
 - CHANGELOG 硬门禁包括当前版本、分类顺序、README 入口、历史完整性、源码编译和回归测试；正反向覆盖等启发式检查默认提示、严格模式阻断
 
 ## 代码规范

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -13,68 +13,41 @@
 
 **体积基线（v2.11）**：Windows 使用 `--onefile` 单文件 EXE，macOS 使用 `--onedir` 生成 `.app` 后再压缩为 ZIP/DMG。两者压缩结构和平台运行库不同，Windows EXE 约 36.4MB、macOS ZIP/DMG 约 31-33MB 属正常范围；不要把 macOS 安装包较小误判为缺依赖或未重建。
 
-### 自动补齐（GitHub Actions）
+### 正式发布（GitHub Actions）
 
-在任一平台本地发布后，`build.py` 会自动删除对端旧产物并触发 CI 重建：
+正式发布的唯一入口是 `.github/workflows/release.yml` 的 `workflow_dispatch`。PR 合并和正式发布是两个独立授权点：合并 `master` 不会自动发布；只有准确提供“正式发布 vX.Y”才会进入发布流程。
 
 ```bash
-# Mac 本地发布
-python build.py --release --version 2.9
-# 打包 macOS → 打 tag → 推送 → 自动删除旧 EXE → CI 构建新 EXE
-
-# Windows 本地发布
-python build.py --release --version 2.9
-# 打包 Windows → 打 tag → 推送 → 自动删除旧 DMG/ZIP → CI 构建新 DMG+ZIP
+gh workflow run release.yml --ref master \
+  -f version=2.21 \
+  -f authorization="正式发布 v2.21" \
+  -f dry_run=false
 ```
 
-**自动触发流程：**
-1. `build.py --release` 在本地平台打包并上传产物
-2. 自动删除 Release 中对端的旧产物（Windows 发布删 DMG/ZIP，macOS 发布删 EXE）
-3. 自动触发 `gh workflow run release.yml`，CI 检测缺失产物并构建
+**自动流程：**
 
-CI 检测 Release 已有产物，只构建缺失的部分：
-- 已有 EXE → CI 只构建 macOS（DMG+ZIP）
-- 已有 DMG+ZIP → CI 只构建 Windows（EXE）
-- 都没有 → CI 两边并行构建
+1. 确认事件来源为手动触发、分支为 `master`、授权文本与版本完全一致。
+2. 锁定不可变的发布提交，执行 `build.py --check --strict-changelog` 等价的完整严格门禁。
+3. Windows 和 macOS 独立并行构建，任一构建失败都不进入发布任务。
+4. 两端产物齐全后创建不可移动的 tag，建立 GitHub Draft Release，上传并校验 EXE、ZIP 和 DMG。
+5. Windows 发布任务将三个产物按 EXE→ZIP→DMG 串行镜像到 Gitee，避免 macOS runner 直连 Gitee 的大文件链路阻塞。
+6. 双 Release 附件完整且 size 一致后，将 GitHub Draft Release 转为正式版本。
+7. 最后生成 `latest.json` 的双源下载地址和 SHA256，提交并推送到 GitHub/Gitee `master`。
+8. 只读核验双远端分支/tag/Release/附件/清单，并实际请求六个公开下载地址和两份在线清单。
+
+**断点续跑：**工作流按“版本 + 发布提交”恢复。已验证的 GitHub 附件直接复用，已存在的同提交 tag 不重建，已一致的 Gitee 附件不重传。同名 tag 指向其他提交、或发布期间 `master` 出现非 `latest.json` 业务变更时立即中止，绝不移动 tag 或强制推送。
+
+**Dry Run：**将 `dry_run` 设为 `true` 时只执行授权校验和严格门禁，不构建、不创建 tag、不推送、不发布。
+
+**Actions 配置：**Repository Secret `GITEE_TOKEN` 需具有 Gitee projects 权限；工作流的 `contents: write` 用于 GitHub tag、Release 和 `latest.json` 提交。本地 `build.py --release` 已停用，防止本地脚本与 Actions 同时修改同一标签和 Release。
 
 Release 页面最终包含：
+
 - `BOSS_ResumeFilter.exe` — Windows 用户
 - `BOSS_ResumeFilter.dmg` — macOS 用户（手动安装）
 - `BOSS_ResumeFilter_mac.zip` — macOS 自动更新用
 
-配置文件：`.github/workflows/release.yml`
-
-**CI 说明：**
-- **CI 构建完成后上传当前平台产物到 GitHub Release；Gitee 由本地发布机同步**
-- macOS 使用 `macos-latest`（Apple Silicon M1）runner，生成的 .app 兼容 Apple Silicon Mac；Intel Mac 用户建议从源码运行
-- 虚拟环境（`.venv-ci`）按 `requirements.txt` hash 缓存，依赖不变时跳过安装
-- 支持 `workflow_dispatch` 手动触发
-- 新版本发布时自动触发对端重建，无需手动删除产物
-
-### Gitee Release 上传（本地并行中转）
-
-本地发布需要 `GITEE_TOKEN` 环境变量（在 https://gitee.com/profile/personal_access_tokens 生成，勾选 projects 权限）。GitHub 托管的 macOS runner 到 Gitee 的大文件上传链路实测会长时间阻塞，因此不在 CI 上传 Gitee。
-
-**上传流程（`build.py --release` 自动执行）：**
-
-1. 上传当前平台产物到 GitHub Release
-2. 触发 CI 构建对端产物
-3. 从本地 `dist/` 上传当前平台产物到 Gitee Release
-4. CI 将对端产物上传 GitHub Release
-5. 本地以最多两路并发下载对端产物并上传 Gitee
-6. 更新 `latest.json` 的 `downloads_cn` 字段并自动提交推送
-
-**传输策略**：macOS ZIP/DMG 最多 2 路并发上传；小文件最多 3 路并发。所有 GitHub/Gitee 上传超时为 600 秒，失败按现有重试策略处理。
-
-**平台顺序**：
-- Windows 本地发布：本地上传 EXE；macOS CI 上传 GitHub 后，本地并行同步 ZIP/DMG 到 Gitee。
-- macOS 本地发布：本地上传 ZIP/DMG；Windows CI 上传 GitHub 后，本地同步 EXE 到 Gitee。
-
-**增量上传**：上传前先比较远端附件和本地产物。能证明内容一致时直接跳过，否则删除旧附件并重传。
-
-**完整性校验**：发布主流程只校验 Gitee 附件齐全且 size 与 GitHub 一致，避免发布后再次回下载三个大文件。需要逐文件 SHA256 审计时运行 `python build.py --verify-gitee-integrity X.Y.Z`。
-
-**tag 不可变**：同名 tag 仅在已经指向当前提交时允许断点续跑；本地或远端 tag 指向其他提交时发布立即中止，不自动覆盖。公开版本出错必须发布更高补丁版本。
+**完整性校验：**发布主流程校验 Gitee 附件齐全且 size 与 GitHub 一致，避免重复回下载三个大文件。需要逐文件 SHA256 审计时运行 `python build.py --verify-gitee-integrity X.Y.Z`。
 
 `latest.json` 字段说明：
 - `downloads`：GitHub 下载链接（国际）
@@ -124,11 +97,11 @@ python build.py --check --strict-changelog
 # 使用自动打包脚本（推荐）
 python build.py
 
-# 一键发布：打包 → 提交 → 打 tag → 推送 → GitHub Release
-python build.py --release
+# 本地只读预检：允许工作区有本轮实现变更，不推送不发布
+python scripts/release_ci.py prepare --version 2.20 --authorization "正式发布 v2.20" --dry-run
 
-# 自动更新版本号 + 一键发布
-python build.py --release --version 2.5
+# PR 合并后正式发布（单独授权）
+gh workflow run release.yml --ref master -f version=2.21 -f authorization="正式发布 v2.21" -f dry_run=false
 
 # 发布完成后只读核验 GitHub/Gitee、附件和 latest.json
 python build.py --verify-release 2.5
@@ -157,9 +130,9 @@ pyinstaller --onefile --noconsole \
 - `python tests/test_import.py` 通过
 - 工作区干净
 
-Release 模式不会再执行 `git add -A`。除 `--version` 自动修改 `gui_main.py` 外，其他变更必须先手工提交，否则发布脚本会中断。
+正式发布工作流不会提交业务代码或自动改版本号；版本号、更新说明和用户文档必须随发布准备 PR 一起合并。
 
-Release 标题和说明必须先写在 `CHANGELOG.md` 对应版本段落中。`python build.py --release` 会自动提取该段落作为 GitHub Release 内容；如果缺少对应版本，或未按以下顺序分类，发布会直接中断：
+Release 标题和说明必须先写在 `CHANGELOG.md` 对应版本段落中。`scripts/release_ci.py` 会自动提取该段落作为 GitHub/Gitee Release 内容；如果缺少对应版本，或未按以下顺序分类，发布会直接中断：
 
 - 新增功能
 - 体验优化
@@ -379,8 +352,8 @@ pip install -r requirements.txt pyinstaller
 # 执行打包（自动检测 macOS 平台）
 python3 build.py
 
-# 或一键发布
-python3 build.py --release
+# 正式发布由 GitHub Actions 双平台构建，不在 Mac 本地执行
+gh workflow run release.yml --ref master -f version=2.21 -f authorization="正式发布 v2.21" -f dry_run=false
 ```
 
 ### 3. 输出文件

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ boss-resume-filter/
 ├── migrate_keys.py       # API Key 迁移工具（明文→加密）
 ├── build.py              # PyInstaller 打包脚本（支持 --release 一键发布）
 ├── build_education_tool.py # 独立学历证书核验助手打包脚本
-├── latest.json           # 版本清单（Gitee 更新源，build.py --release 自动维护）
+├── latest.json           # 双源版本清单（正式发布工作流自动维护）
 ├── gui.bat               # GUI 启动脚本
 ├── job_config.json       # 岗位筛选规则配置
 ├── api_config.json       # 发布默认 AI 模型配置模板（不含明文 Key）
@@ -294,7 +294,8 @@ boss-resume-filter/
 ├── install.bat           # 安装脚本
 ├── tests/                # 测试脚本目录
 ├── scripts/              # 辅助脚本目录
-│   └── watch_progress.py # 发布进度监控脚本
+│   ├── release_ci.py   # GitHub Actions 正式发布编排与线上验收
+│   └── watch_progress.py # 本地打包进度监控脚本
 ├── pyinstaller-hooks/    # PyInstaller 自定义 hook（控制模块收集范围，减小产物体积）
 └── .build_progress.json  # 发布进度文件（build.py 实时更新，供外部监控）
 ```

--- a/build.py
+++ b/build.py
@@ -5,9 +5,8 @@ BOSS 简历筛选器 - 打包脚本
   python build.py --user-audit           用户视角发布审计，不打包、不提交、不推送
   python build.py --check --strict-changelog  启用严格 CHANGELOG/README/latest.json 文案门禁
   python build.py                      仅打包 + 版本核对
-  python build.py --release            打包 → 提交 → 打 tag → 推送 → GitHub Release
-  python build.py --release --version 2.5  自动更新 __version__ + 一键发布
-  python build.py --ci --release       CI 模式：跳过 venv/git，由 GitHub Actions 调用
+  python build.py --ci --release       GitHub Actions 单平台构建（内部使用）
+  gh workflow run release.yml ...      手动授权后触发正式发布
   python build.py --github-upload X.Y.Z 手动补传产物到 GitHub Release
   python build.py --gitee-upload X.Y.Z 手动补传产物到 Gitee Release
   python build.py --verify-gitee-integrity X.Y.Z 严格回下载校验 Gitee SHA256
@@ -3980,14 +3979,15 @@ def _gitee_get_release_cache(version, release_title, release_notes):
         return None
 
 
-def _gitee_upload_local(version, release_title, release_notes, release_cache=None):
-    """上传本地平台的产物到 Gitee Release。
+def _gitee_upload_artifacts(version, release_title, release_notes, artifact_paths,
+                             release_cache=None, large_workers=1,
+                             fail_fast=False):
+    """Upload an explicit artifact set to Gitee with idempotent checks.
 
-    Windows: EXE
-    macOS:   DMG + ZIP
-
-    返回 downloads_cn 字典。需要环境变量 GITEE_TOKEN，未设置时返回 None。
-    release_cache: 可选的缓存信息（来自 _gitee_get_release_cache），避免重复 API 调用。
+    This platform-neutral entrypoint is used by the hosted release workflow,
+    which downloads the Windows and macOS build artifacts into one workspace
+    before publishing.  It returns canonical ``downloads_cn`` entries for all
+    successfully verified files, or ``None`` when any upload fails.
     """
     # 如果没有传入缓存，则获取缓存
     if release_cache is None:
@@ -4003,22 +4003,8 @@ def _gitee_upload_local(version, release_title, release_notes, release_cache=Non
     release_id = release_cache['release_id']
     existing = release_cache['existing']
 
-    if IS_MAC:
-        # ZIP/DMG 均已在当前 runner 构建完成，最多两路并发上传。
-        batch1 = [
-            DIST_DIR / "BOSS_ResumeFilter_mac.zip",
-            DIST_DIR / "BOSS_ResumeFilter.dmg",
-        ]
-        batch2 = []
-    else:
-        batch1 = [
-            DIST_DIR / "BOSS_ResumeFilter.exe",
-        ]
-        batch2 = []
-
-    # 过滤存在的文件
-    batch1 = [f for f in batch1 if f.exists()]
-    batch2 = [f for f in batch2 if f.exists()]
+    files = [Path(path) for path in artifact_paths]
+    files = [path for path in files if path.exists() and path.is_file()]
 
     try:
         downloads_cn = {}
@@ -4054,24 +4040,37 @@ def _gitee_upload_local(version, release_title, release_notes, release_cache=Non
             def _upload_failure(f, error):
                 print(f"  [失败] Gitee 上传失败: {f.name} ({error})")
                 failed.append(f.name)
+                if fail_fast:
+                    raise error
 
-            _run_transfer_batch(
-                to_upload,
-                label,
-                lambda f: _gitee_upload_single(f, api_base, token, release_id),
-                _upload_success,
-                _upload_failure,
-                large_workers=2 if IS_MAC else 1,
-            )
+            if fail_fast:
+                for f in to_upload:
+                    print(f"  {label} 串行: {f.name}")
+                    try:
+                        result = _gitee_upload_single(
+                            f, api_base, token, release_id
+                        )
+                        _upload_success(f, result)
+                    except Exception as error:
+                        _upload_failure(f, error)
+            else:
+                _run_transfer_batch(
+                    to_upload,
+                    label,
+                    lambda f: _gitee_upload_single(f, api_base, token, release_id),
+                    _upload_success,
+                    _upload_failure,
+                    large_workers=max(1, int(large_workers)),
+                )
 
-        _process_and_upload(batch1, "上传本地产物到 Gitee")
-        _process_and_upload(batch2, "上传补充产物到 Gitee")
+        _process_and_upload(files, "上传发布产物到 Gitee")
 
         if failed:
             print(f"\n{'!'*60}")
             print(f"  [!!]  Gitee 上传部分失败: {', '.join(failed)}")
             print(f"  手动补传: python build.py --gitee-upload {version}")
             print(f"{'!'*60}\n")
+            return None
 
         return downloads_cn if downloads_cn else None
 
@@ -4081,6 +4080,27 @@ def _gitee_upload_local(version, release_title, release_notes, release_cache=Non
         print(f"  手动补传: python build.py --gitee-upload {version}")
         print(f"{'!'*60}\n")
         return None
+
+
+def _gitee_upload_local(version, release_title, release_notes, release_cache=None):
+    """Upload the artifacts built on the current local platform to Gitee."""
+    if IS_MAC:
+        artifacts = [
+            DIST_DIR / "BOSS_ResumeFilter_mac.zip",
+            DIST_DIR / "BOSS_ResumeFilter.dmg",
+        ]
+        workers = 2
+    else:
+        artifacts = [DIST_DIR / "BOSS_ResumeFilter.exe"]
+        workers = 1
+    return _gitee_upload_artifacts(
+        version,
+        release_title,
+        release_notes,
+        artifacts,
+        release_cache=release_cache,
+        large_workers=workers,
+    )
 
 
 def _downloads_cn_key(filename):
@@ -4364,7 +4384,7 @@ def main():
     parser.add_argument("--user-audit", action="store_true",
                         help="用户视角发布审计，不打包、不提交、不推送")
     parser.add_argument("--release", action="store_true",
-                        help="打包后自动提交→打tag→推送→GitHub Release上传")
+                        help="仅与 --ci 配合供 GitHub Actions 构建使用")
     parser.add_argument("--version", type=str, default=None, metavar="X.Y",
                         help="自动更新 gui_main.py 中的 __version__")
     parser.add_argument("--ci", action="store_true",
@@ -4394,6 +4414,19 @@ def main():
     parser.add_argument("--strict-changelog", action="store_true",
                         help="将 CHANGELOG 启发式覆盖、README 逐条镜像和 latest.json 同步检查作为硬门禁")
     args = parser.parse_args()
+
+    if args.release and not args.ci:
+        requested_version = (args.version or _read_version()).removeprefix("v")
+        _validate_version_format(requested_version)
+        authorization = f"正式发布 v{requested_version}"
+        print("本地 build.py --release 已停用，避免与双平台发布流水线并发修改标签。")
+        print("请在 PR 合并后单独授权，并手动触发 Build & Release：")
+        print(
+            "  gh workflow run release.yml --ref master "
+            f"-f version={requested_version} "
+            f"-f authorization=\"{authorization}\" -f dry_run=false"
+        )
+        sys.exit(2)
 
     version_changed = False
 
@@ -4519,7 +4552,7 @@ def main():
         # 检查 Release 是否存在
         r = subprocess.run(["gh", "release", "view", tag], capture_output=True, cwd=BASE_DIR)
         if r.returncode != 0:
-            print(f"[错误] GitHub Release {tag} 不存在，请先运行 python build.py --release --version {version}")
+            print(f"[错误] GitHub Release {tag} 不存在，请先触发 Build & Release 工作流")
             sys.exit(1)
 
         # 从 GitHub Release 读取 release notes
@@ -4968,8 +5001,8 @@ def main():
         print(f"  GitHub Actions 将自动上传到 Release")
         print(f"{'='*60}\n")
     else:
-        print(f"\n  下一步：python build.py --release  一键完成提交/打tag/推送/Release")
-        print(f"  或手动：git push origin master && git push origin v{version}\n")
+        print("\n  正式发布：先合并发布准备 PR，再单独触发 Build & Release")
+        print(f"  授权文本：正式发布 v{version}\n")
 
 
 if __name__ == "__main__":

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # scripts 目录说明
 
-本目录放辅助脚本，不属于主程序运行路径，也不进入稳定回归。
+本目录放辅助脚本，不属于主程序运行路径。正式交付脚本应有对应单元测试；仅浏览器/人工工具不进入稳定回归。
 
 默认验收命令仍然是：
 
@@ -11,7 +11,8 @@ python tests/test_import.py
 
 ## 活跃脚本
 
-- `watch_progress.py`：发布进度监控脚本，轮询 `.build_progress.json` 并输出状态变化。被 `build.py --release` 的外部监控流程调用。
+- `release_ci.py`：`Build & Release` 的确定性发布编排，负责一次授权、严格门禁、双远端发布、断点续跑和线上验收；行为测试在 `tests/unit/test_release_ci.py`。
+- `watch_progress.py`：轮询 `.build_progress.json` 并输出本地打包状态，保留作为手工构建辅助工具。
 
 ## archive/ — 历史脚本归档
 

--- a/scripts/release_ci.py
+++ b/scripts/release_ci.py
@@ -1,0 +1,676 @@
+"""Hosted, single-authorization release orchestration.
+
+The GitHub Actions workflow calls this module in two phases:
+
+``prepare``
+    Validate the explicit release authorization, resolve the immutable release
+    commit, run the strict project gate, and decide which platform artifacts
+    still need building.
+
+``publish``
+    Create or reuse the immutable tag, stage and publish GitHub/Gitee releases,
+    update ``latest.json`` on ``master``, mirror the final commit to Gitee, and
+    perform the public post-release checks.
+
+The implementation deliberately reuses ``build.py`` for version, changelog,
+artifact, upload, and integrity contracts.  YAML remains orchestration only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from urllib.parse import quote
+
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
+
+import build  # noqa: E402
+
+
+RELEASE_ARTIFACTS = (
+    "BOSS_ResumeFilter.exe",
+    "BOSS_ResumeFilter_mac.zip",
+    "BOSS_ResumeFilter.dmg",
+)
+RESUME_ONLY_MASTER_CHANGES = frozenset({"latest.json"})
+GITEE_OWNER = "yaoyouzhong"
+GITEE_REPO = "boss-resume-filter"
+
+
+class ReleaseAutomationError(RuntimeError):
+    """A deterministic release contract was not satisfied."""
+
+
+def _fail(message: str) -> None:
+    raise ReleaseAutomationError(message)
+
+
+def _run(
+    args: list[str],
+    *,
+    check: bool = True,
+    capture_output: bool = False,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=BASE_DIR,
+        check=check,
+        capture_output=capture_output,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+    )
+
+
+def _git_text(*args: str) -> str:
+    result = _run(["git", *args], capture_output=True)
+    return result.stdout.strip()
+
+
+def _normalize_version(value: str) -> str:
+    version = str(value or "").strip().removeprefix("v")
+    build._validate_version_format(version)
+    return version
+
+
+def expected_authorization(version: str) -> str:
+    return f"正式发布 v{version}"
+
+
+def validate_authorization(version: str, authorization: str) -> None:
+    expected = expected_authorization(version)
+    if authorization != expected:
+        _fail(f"发布授权不匹配：必须准确填写 {expected!r}")
+
+
+def _version_at_ref(ref: str) -> str:
+    source = _git_text("show", f"{ref}:gui_main.py")
+    match = re.search(r'^__version__\s*=\s*["\']([^"\']+)["\']', source, re.MULTILINE)
+    if not match:
+        _fail(f"无法从 {ref[:12]} 的 gui_main.py 读取版本号")
+    return match.group(1)
+
+
+def _is_ancestor(ancestor: str, descendant: str) -> bool:
+    result = _run(
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+        check=False,
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def _changed_paths(base: str, head: str) -> set[str]:
+    output = _git_text("diff", "--name-only", f"{base}..{head}")
+    return {line.strip().replace("\\", "/") for line in output.splitlines() if line.strip()}
+
+
+def _assert_resume_head_compatible(release_sha: str, master_sha: str) -> None:
+    if release_sha == master_sha:
+        return
+    if not _is_ancestor(release_sha, master_sha):
+        _fail("当前 master 不是发布提交的后继，拒绝续跑")
+    changed = _changed_paths(release_sha, master_sha)
+    unexpected = sorted(changed - RESUME_ONLY_MASTER_CHANGES)
+    if unexpected:
+        _fail(
+            "同版本续跑期间 master 已包含新的业务变更，拒绝复用旧标签："
+            + ", ".join(unexpected)
+        )
+
+
+def resolve_release_sha(version: str) -> tuple[str, bool]:
+    """Resolve the release commit, allowing only a manifest-only resume."""
+    head_sha = _git_text("rev-parse", "HEAD")
+    origin_master = build._remote_ref_commit("origin", "refs/heads/master")
+    if not origin_master:
+        _fail("无法读取 origin/master")
+    if head_sha != origin_master:
+        _fail("正式发布只能从当前 origin/master 提交触发")
+
+    tag = f"v{version}"
+    tag_sha = build._remote_tag_commit("origin", tag)
+    release_sha = tag_sha or head_sha
+    if tag_sha:
+        _assert_resume_head_compatible(tag_sha, head_sha)
+
+    source_version = _version_at_ref(release_sha)
+    if source_version != version:
+        _fail(
+            f"发布提交版本为 {source_version!r}，与请求版本 {version!r} 不一致"
+        )
+    return release_sha, bool(tag_sha)
+
+
+def _asset_has_integrity(asset: dict | None) -> bool:
+    if not asset:
+        return False
+    try:
+        size = int(asset.get("size") or 0)
+    except (TypeError, ValueError):
+        return False
+    return size > 0 and bool(build._asset_digest_sha256(asset))
+
+
+def _write_github_outputs(path: str | None, values: dict[str, str]) -> None:
+    output_path = path or os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with open(output_path, "a", encoding="utf-8") as output:
+        for key, value in values.items():
+            output.write(f"{key}={value}\n")
+
+
+def prepare_release(
+    version: str,
+    authorization: str,
+    *,
+    dry_run: bool = False,
+    github_output: str | None = None,
+) -> dict[str, str]:
+    """Run the strict, mutation-free release preparation gate."""
+    version = _normalize_version(version)
+    validate_authorization(version, authorization)
+
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        if os.environ.get("GITHUB_EVENT_NAME") != "workflow_dispatch":
+            _fail("正式发布工作流只能由 workflow_dispatch 手动触发")
+        if os.environ.get("GITHUB_REF_NAME") != "master":
+            _fail("正式发布工作流只能从 master 触发")
+
+    release_sha, resume = resolve_release_sha(version)
+    release_title, _release_notes = build._extract_changelog_release(version)
+
+    # A local dry run may inspect an intentionally dirty implementation branch.
+    # Hosted dry runs still start from a clean checkout, but do not need a
+    # special code path.
+    build._preflight_checks(
+        require_clean=not dry_run,
+        strict_changelog=True,
+    )
+
+    tag = f"v{version}"
+    remote_assets = build._get_github_release_assets(tag) if resume else {}
+    needs_windows = not _asset_has_integrity(remote_assets.get(RELEASE_ARTIFACTS[0]))
+    needs_macos = not all(
+        _asset_has_integrity(remote_assets.get(name))
+        for name in RELEASE_ARTIFACTS[1:]
+    )
+
+    outputs = {
+        "version": version,
+        "tag": tag,
+        "release_sha": release_sha,
+        "resume": str(resume).lower(),
+        "needs_windows": str(needs_windows).lower(),
+        "needs_macos": str(needs_macos).lower(),
+    }
+    _write_github_outputs(github_output, outputs)
+
+    mode = "断点续跑" if resume else "首次发布"
+    print(f"\n[OK] {tag} 发布准备通过（{mode}）")
+    print(f"  发布提交: {release_sha}")
+    print(f"  Release 标题: {release_title}")
+    print(f"  Windows 构建: {'需要' if needs_windows else '复用'}")
+    print(f"  macOS 构建: {'需要' if needs_macos else '复用'}")
+    if dry_run:
+        print("  Dry Run：未创建标签、未上传附件、未发布")
+    return outputs
+
+
+def _notes_file(title: str, body: str) -> Path:
+    handle = tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        suffix=".md",
+        prefix="release_notes_",
+        delete=False,
+    )
+    try:
+        handle.write(f"{title}\n\n{body}\n")
+    finally:
+        handle.close()
+    return Path(handle.name)
+
+
+def _commit_for_ref(ref: str) -> str | None:
+    result = _run(
+        ["git", "rev-list", "-n", "1", ref],
+        check=False,
+        capture_output=True,
+    )
+    return (result.stdout.strip() or None) if result.returncode == 0 else None
+
+
+def _ensure_origin_tag(tag: str, release_sha: str, notes_path: Path) -> None:
+    remote_sha = build._remote_tag_commit("origin", tag)
+    if remote_sha and remote_sha != release_sha:
+        _fail(f"origin/{tag} 指向其他提交，禁止移动公开标签")
+
+    local_sha = _commit_for_ref(tag)
+    if local_sha and local_sha != release_sha:
+        _fail(f"本地 {tag} 指向其他提交，禁止覆盖")
+    if not local_sha:
+        _run(["git", "tag", "-a", tag, release_sha, "-F", str(notes_path)])
+        print(f"  [OK] 已创建 annotated tag: {tag}")
+
+    if not remote_sha:
+        _run(["git", "push", "origin", f"refs/tags/{tag}"])
+        print(f"  [OK] 已推送 GitHub tag: {tag}")
+    else:
+        print(f"  [跳过] GitHub tag 已存在且提交一致: {tag}")
+
+
+def _require_publish_secrets() -> str:
+    if not (os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")):
+        _fail("缺少 GH_TOKEN/GITHUB_TOKEN，无法发布 GitHub Release")
+    token = os.environ.get("GITEE_TOKEN", "")
+    if not token:
+        _fail("缺少 GITEE_TOKEN，无法完成双远端发布")
+    return token
+
+
+def _sanitized_git_push(url: str, refspec: str, token: str) -> None:
+    result = _run(
+        ["git", "push", url, refspec],
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode == 0:
+        return
+    encoded = quote(token, safe="")
+    detail = (result.stderr or result.stdout or "git push failed")
+    detail = detail.replace(token, "***").replace(encoded, "***")
+    _fail(f"Gitee 推送失败：{detail.strip()}")
+
+
+def _gitee_authenticated_url(token: str) -> str:
+    encoded = quote(token, safe="")
+    return f"https://{GITEE_OWNER}:{encoded}@gitee.com/{GITEE_OWNER}/{GITEE_REPO}.git"
+
+
+def _ensure_gitee_remote() -> None:
+    """Ensure hosted runners have the public Gitee remote used by verifiers."""
+    expected = f"https://gitee.com/{GITEE_OWNER}/{GITEE_REPO}.git"
+    current = _run(
+        ["git", "remote", "get-url", "gitee"],
+        check=False,
+        capture_output=True,
+    )
+    if current.returncode != 0:
+        _run(["git", "remote", "add", "gitee", expected])
+        return
+    url = current.stdout.strip().removesuffix("/")
+    accepted_suffix = f"gitee.com/{GITEE_OWNER}/{GITEE_REPO}.git"
+    if not url.endswith(accepted_suffix):
+        _fail(f"gitee remote 指向非预期仓库：{url}")
+
+
+def _ensure_gitee_tag(tag: str, release_sha: str, token: str) -> None:
+    remote_sha = build._remote_tag_commit("gitee", tag)
+    if remote_sha and remote_sha != release_sha:
+        _fail(f"gitee/{tag} 指向其他提交，禁止移动公开标签")
+    if remote_sha:
+        print(f"  [跳过] Gitee tag 已存在且提交一致: {tag}")
+        return
+    _sanitized_git_push(
+        _gitee_authenticated_url(token),
+        f"refs/tags/{tag}:refs/tags/{tag}",
+        token,
+    )
+    verified = build._remote_tag_commit("gitee", tag)
+    if verified != release_sha:
+        _fail("Gitee tag 推送后校验失败")
+    print(f"  [OK] 已推送 Gitee tag: {tag}")
+
+
+def _ensure_github_release(tag: str, title: str, body: str) -> dict | None:
+    notes_path = _notes_file(title, body)
+    body_path = notes_path.with_name(notes_path.stem + "_body.md")
+    body_path.write_text(body + "\n", encoding="utf-8")
+    try:
+        info = build._get_github_release_info(tag)
+        if info is None:
+            _run([
+                "gh", "release", "create", tag,
+                "--draft",
+                "--verify-tag",
+                "--title", title,
+                "--notes-file", str(body_path),
+            ])
+            print(f"  [OK] 已创建 GitHub Draft Release: {tag}")
+            return build._get_github_release_info(tag)
+
+        if info.get("tagName") != tag:
+            _fail("GitHub Release 的标签与请求不一致")
+        _run([
+            "gh", "release", "edit", tag,
+            "--title", title,
+            "--notes-file", str(body_path),
+        ])
+        print(f"  [跳过] GitHub Release 已存在，已同步标题和说明: {tag}")
+        return build._get_github_release_info(tag)
+    finally:
+        notes_path.unlink(missing_ok=True)
+        body_path.unlink(missing_ok=True)
+
+
+def _ensure_local_artifacts(tag: str) -> list[Path]:
+    build.DIST_DIR.mkdir(parents=True, exist_ok=True)
+    remote_assets = build._get_github_release_assets(tag)
+    paths: list[Path] = []
+    for name in RELEASE_ARTIFACTS:
+        path = build.DIST_DIR / name
+        if not path.exists() and name in remote_assets:
+            print(f"  [复用] 从现有 GitHub Release 下载: {name}")
+            build._download_from_github_release(tag, name, build.DIST_DIR)
+        if not path.exists() or path.stat().st_size <= 0:
+            _fail(f"发布产物缺失或为空：{name}")
+        paths.append(path)
+    return paths
+
+
+def _upload_github_artifacts(tag: str, artifacts: list[Path]) -> dict:
+    remote_assets = build._get_github_release_assets(tag)
+    for path in artifacts:
+        remote = remote_assets.get(path.name)
+        if remote:
+            same, reason = build._github_asset_matches_local(tag, path, remote)
+            if same:
+                print(f"  [跳过] GitHub 已有且一致: {path.name} ({reason})")
+                continue
+            print(f"  [更新] GitHub {path.name}: {reason}")
+        build._upload_github_release_asset(tag, path)
+        if not build._ensure_github_release_asset_matches_local(tag, path):
+            _fail(f"GitHub 附件上传后校验失败：{path.name}")
+    verified = build._verify_github_release_assets_complete(tag)
+    if verified is None:
+        _fail("GitHub Release 附件完整性校验失败")
+    return verified
+
+
+def _canonical_downloads_cn(version: str) -> dict[str, str]:
+    base = f"https://gitee.com/{GITEE_OWNER}/{GITEE_REPO}/releases/download/v{version}"
+    return {
+        "windows": f"{base}/BOSS_ResumeFilter.exe",
+        "macos": f"{base}/BOSS_ResumeFilter_mac.zip",
+        "macos_dmg": f"{base}/BOSS_ResumeFilter.dmg",
+    }
+
+
+def _publish_gitee_artifacts(
+    version: str,
+    title: str,
+    body: str,
+    artifacts: list[Path],
+    github_assets: dict,
+) -> dict[str, str]:
+    cache = build._gitee_get_release_cache(version, title, body)
+    if cache is None:
+        _fail("无法创建或读取 Gitee Release")
+    uploaded = build._gitee_upload_artifacts(
+        version,
+        title,
+        body,
+        artifacts,
+        release_cache=cache,
+        large_workers=1,
+        fail_fast=True,
+    )
+    if not uploaded:
+        _fail("Gitee Release 附件上传失败")
+    if not build._verify_gitee_release_assets_complete(
+        f"v{version}", github_assets, cache
+    ):
+        _fail("Gitee Release 附件完整性校验失败")
+    return _canonical_downloads_cn(version)
+
+
+def _publish_github_release(tag: str) -> None:
+    info = build._get_github_release_info(tag)
+    if info is None:
+        _fail("GitHub Release 不存在")
+    if info.get("isDraft"):
+        _run(["gh", "release", "edit", tag, "--draft=false"])
+        print(f"  [OK] GitHub Release 已正式发布: {tag}")
+    else:
+        print(f"  [跳过] GitHub Release 已是正式版本: {tag}")
+
+
+def _fetch_and_assert_current_master_compatible(release_sha: str) -> str:
+    """Re-read origin/master and reject an unsafe release/resume race."""
+    _run(["git", "fetch", "origin", "master"])
+    master_sha = build._remote_ref_commit("origin", "refs/heads/master")
+    if not master_sha:
+        _fail("无法读取最新 origin/master")
+    _assert_resume_head_compatible(release_sha, master_sha)
+    return master_sha
+
+
+def _switch_to_current_master(release_sha: str) -> str:
+    master_sha = _fetch_and_assert_current_master_compatible(release_sha)
+    _run(["git", "switch", "-C", "master", "origin/master"])
+    return master_sha
+
+
+def _commit_and_sync_manifest(
+    version: str,
+    body: str,
+    downloads_cn: dict[str, str],
+    github_assets: dict,
+    release_sha: str,
+    gitee_token: str,
+) -> str:
+    _switch_to_current_master(release_sha)
+    metadata = build._release_asset_metadata_from_remote_assets(github_assets.values())
+    build._assert_update_asset_metadata_complete(metadata)
+    changed = build.update_latest_json(
+        version,
+        body,
+        downloads_cn,
+        asset_metadata=metadata,
+        require_complete_assets=True,
+    )
+    if changed:
+        status_lines = _git_text("status", "--porcelain").splitlines()
+        changed_paths = {
+            line[3:].split(" -> ", 1)[-1].replace("\\", "/")
+            for line in status_lines
+            if line.strip()
+        }
+        if changed_paths != {"latest.json"}:
+            _fail(
+                "更新自动更新清单时出现非预期文件："
+                + ", ".join(sorted(changed_paths))
+            )
+        _run(["git", "config", "user.name", "github-actions[bot]"])
+        _run([
+            "git", "config", "user.email",
+            "41898282+github-actions[bot]@users.noreply.github.com",
+        ])
+        _run(["git", "add", "latest.json"])
+        _run(["git", "commit", "-m", "chore: 更新自动更新清单"])
+        _run(["git", "push", "origin", "master"])
+        print("  [OK] latest.json 已提交并推送到 GitHub master")
+    else:
+        print("  [跳过] latest.json 已一致")
+
+    current_master = _git_text("rev-parse", "HEAD")
+    _sanitized_git_push(
+        _gitee_authenticated_url(gitee_token),
+        "HEAD:refs/heads/master",
+        gitee_token,
+    )
+    if build._remote_ref_commit("gitee", "refs/heads/master") != current_master:
+        _fail("Gitee master 推送后校验失败")
+    print("  [OK] Gitee master 已同步")
+    return current_master
+
+
+def _request_ok(url: str) -> bool:
+    headers = {"Range": "bytes=0-0"}
+    try:
+        response = build.requests.head(url, allow_redirects=True, timeout=30)
+        if response.status_code < 400:
+            return True
+        response = build.requests.get(
+            url,
+            headers=headers,
+            allow_redirects=True,
+            stream=True,
+            timeout=30,
+        )
+        try:
+            return response.status_code < 400
+        finally:
+            response.close()
+    except build.requests.exceptions.RequestException:
+        return False
+
+
+def verify_public_endpoints(version: str, attempts: int = 6, delay: int = 10) -> None:
+    """Verify public downloads plus both remotely served manifests."""
+    version = _normalize_version(version)
+    latest = json.loads((BASE_DIR / "latest.json").read_text(encoding="utf-8"))
+    urls = [
+        *latest.get("downloads", {}).values(),
+        *latest.get("downloads_cn", {}).values(),
+    ]
+    if len(urls) != 6:
+        _fail("latest.json 未包含六个双源公开下载地址")
+
+    manifest_urls = (
+        f"https://raw.githubusercontent.com/{GITEE_OWNER}/{GITEE_REPO}/master/latest.json",
+        f"https://gitee.com/{GITEE_OWNER}/{GITEE_REPO}/raw/master/latest.json",
+    )
+    last_errors: list[str] = []
+    for attempt in range(1, attempts + 1):
+        last_errors = [url for url in urls if not _request_ok(url)]
+        for url in manifest_urls:
+            try:
+                response = build.requests.get(url, timeout=30)
+                response.raise_for_status()
+                remote = response.json()
+                if remote.get("version") != version:
+                    last_errors.append(f"{url} -> {remote.get('version')!r}")
+            except (build.requests.exceptions.RequestException, ValueError) as exc:
+                last_errors.append(f"{url} -> {type(exc).__name__}")
+        if not last_errors:
+            print("  [OK] 六个公开下载地址和双远端在线清单均可用")
+            return
+        if attempt < attempts:
+            print(f"  [等待] 公开资源尚未全部生效（{attempt}/{attempts}）")
+            time.sleep(delay)
+    _fail("公开资源验收失败：" + "; ".join(last_errors))
+
+
+def publish_release(
+    version: str,
+    authorization: str,
+    release_sha: str,
+) -> None:
+    """Publish or resume one release from its immutable source commit."""
+    version = _normalize_version(version)
+    validate_authorization(version, authorization)
+    gitee_token = _require_publish_secrets()
+    _ensure_gitee_remote()
+    release_sha = release_sha.strip()
+    head_sha = _git_text("rev-parse", "HEAD")
+    if head_sha != release_sha:
+        _fail("publish job 未检出 prepare 阶段确定的发布提交")
+    if _version_at_ref(release_sha) != version:
+        _fail("发布提交版本与请求版本不一致")
+
+    # Build jobs can run for tens of minutes.  Recheck master before the first
+    # remote mutation, then once more immediately before making GitHub public.
+    _fetch_and_assert_current_master_compatible(release_sha)
+
+    tag = f"v{version}"
+    title, body = build._extract_changelog_release(version)
+    tag_notes = _notes_file(title, body)
+    try:
+        _ensure_origin_tag(tag, release_sha, tag_notes)
+    finally:
+        tag_notes.unlink(missing_ok=True)
+    _ensure_gitee_tag(tag, release_sha, gitee_token)
+
+    _ensure_github_release(tag, title, body)
+    artifacts = _ensure_local_artifacts(tag)
+    github_assets = _upload_github_artifacts(tag, artifacts)
+    downloads_cn = _publish_gitee_artifacts(
+        version, title, body, artifacts, github_assets
+    )
+
+    # Publicize only after both release stores have complete artifacts.
+    _fetch_and_assert_current_master_compatible(release_sha)
+    _publish_github_release(tag)
+    _commit_and_sync_manifest(
+        version,
+        body,
+        downloads_cn,
+        github_assets,
+        release_sha,
+        gitee_token,
+    )
+
+    if not build._verify_release_remote_state(version):
+        _fail("双远端发布状态核验失败")
+    verify_public_endpoints(version)
+    print(f"\n[OK] {tag} 正式发布、自动更新清单和线上验收全部完成")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="GitHub Actions 正式发布编排")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare = subparsers.add_parser("prepare", help="运行无副作用严格门禁")
+    prepare.add_argument("--version", required=True)
+    prepare.add_argument("--authorization", required=True)
+    prepare.add_argument("--github-output")
+    prepare.add_argument("--dry-run", action="store_true")
+
+    publish = subparsers.add_parser("publish", help="发布或断点续跑")
+    publish.add_argument("--version", required=True)
+    publish.add_argument("--authorization", required=True)
+    publish.add_argument("--release-sha", required=True)
+
+    verify = subparsers.add_parser("verify-public", help="核验公开下载和在线清单")
+    verify.add_argument("--version", required=True)
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+    try:
+        if args.command == "prepare":
+            env_dry_run = os.environ.get("RELEASE_DRY_RUN", "").lower() == "true"
+            prepare_release(
+                args.version,
+                args.authorization,
+                dry_run=args.dry_run or env_dry_run,
+                github_output=args.github_output,
+            )
+        elif args.command == "publish":
+            publish_release(args.version, args.authorization, args.release_sha)
+        else:
+            verify_public_endpoints(args.version)
+    except ReleaseAutomationError as exc:
+        print(f"[错误] {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_packaging_dependencies.py
+++ b/tests/unit/test_packaging_dependencies.py
@@ -36,16 +36,45 @@ def test_release_workflow_rebuilds_macos_when_dmg_is_missing():
     """macOS release completeness requires both the auto-update ZIP and installer DMG."""
     workflow = (BASE_DIR / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
 
-    assert "BOSS_ResumeFilter_mac\\.zip" in workflow
-    assert "BOSS_ResumeFilter\\.dmg" in workflow
+    assert "BOSS_ResumeFilter_mac.zip" in workflow
+    assert "BOSS_ResumeFilter.dmg" in workflow
 
 
-def test_release_workflow_does_not_upload_to_gitee_from_github_runner():
-    """GitHub-hosted macOS runners are too slow for reliable Gitee large-file uploads."""
+def test_release_workflow_publishes_gitee_only_after_both_platform_builds():
+    """The publish job owns serial Gitee mirroring after both build jobs finish."""
     workflow = (BASE_DIR / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
 
-    assert "GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}" not in workflow
-    assert '--gitee-upload-local "$VERSION"' not in workflow
+    assert "needs: [prepare, build_windows, build_macos]" in workflow
+    assert "runs-on: windows-latest" in workflow
+    assert "GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}" in workflow
+    assert "scripts/release_ci.py publish" in workflow
+
+
+def test_release_workflow_requires_one_explicit_authorization_and_never_auto_triggers():
+    """Merging master must not publish; one manual authorization starts the full workflow."""
+    workflow = (BASE_DIR / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in workflow
+    assert "authorization:" in workflow
+    assert "Exact authorization text: 正式发布 vX.Y" in workflow
+    assert "dry_run:" in workflow
+    assert "push:" not in workflow
+    assert "pull_request:" not in workflow
+    assert "cancel-in-progress: false" in workflow
+    assert "queue: max" in workflow
+    assert "python scripts/release_ci.py prepare" in workflow
+    assert "python build.py --ci --release --strict-changelog" in workflow
+    assert '--authorization "${{ inputs.authorization }}"' not in workflow
+    assert '--authorization "$env:RELEASE_AUTHORIZATION"' in workflow
+
+
+def test_local_release_entrypoint_cannot_race_the_hosted_release_workflow():
+    """Formal releases have one mutation owner: the hosted workflow."""
+    build_source = (BASE_DIR / "build.py").read_text(encoding="utf-8")
+
+    assert "if args.release and not args.ci:" in build_source
+    assert "本地 build.py --release 已停用" in build_source
+    assert "gh workflow run release.yml --ref master" in build_source
 
 
 def test_pr_checks_run_stable_validation_for_master_pull_requests():

--- a/tests/unit/test_release_ci.py
+++ b/tests/unit/test_release_ci.py
@@ -1,0 +1,253 @@
+import importlib.util
+from pathlib import Path
+import tempfile
+from contextlib import contextmanager
+from unittest.mock import patch
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "boss_resume_filter_release_ci",
+    BASE_DIR / "scripts" / "release_ci.py",
+)
+assert SPEC and SPEC.loader
+release_ci = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(release_ci)
+
+
+def _asset(size: int = 123) -> dict:
+    return {"size": size, "digest": "sha256:" + "a" * 64}
+
+
+@contextmanager
+def _raises(error_type, message: str):
+    try:
+        yield
+    except error_type as exc:
+        assert message in str(exc)
+    else:
+        raise AssertionError(f"expected {error_type.__name__}: {message}")
+
+
+def test_release_authorization_must_match_version_exactly():
+    release_ci.validate_authorization("2.21", "正式发布 v2.21")
+
+    with _raises(release_ci.ReleaseAutomationError, "发布授权不匹配"):
+        release_ci.validate_authorization("2.21", "release 2.21")
+
+
+def test_resume_rejects_new_business_changes_after_the_release_commit():
+    with (
+        patch.object(release_ci, "_is_ancestor", return_value=True),
+        patch.object(
+            release_ci,
+            "_changed_paths",
+            return_value={"latest.json", "gui_main.py"},
+        ),
+    ):
+        with _raises(release_ci.ReleaseAutomationError, "新的业务变更"):
+            release_ci._assert_resume_head_compatible("a" * 40, "b" * 40)
+
+
+def test_resume_allows_only_the_post_release_manifest_commit():
+    with (
+        patch.object(release_ci, "_is_ancestor", return_value=True),
+        patch.object(release_ci, "_changed_paths", return_value={"latest.json"}),
+    ):
+        release_ci._assert_resume_head_compatible("a" * 40, "b" * 40)
+
+
+def test_prepare_reuses_complete_remote_artifacts_on_same_commit_resume():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output = Path(temp_dir) / "github-output.txt"
+        remote_assets = {
+            "BOSS_ResumeFilter.exe": _asset(),
+            "BOSS_ResumeFilter_mac.zip": _asset(),
+            "BOSS_ResumeFilter.dmg": _asset(),
+        }
+        with (
+            patch.object(release_ci, "resolve_release_sha", return_value=("a" * 40, True)),
+            patch.object(
+                release_ci.build,
+                "_extract_changelog_release",
+                return_value=("v2.21 — Test", "### 新增功能\n\n- Test"),
+            ),
+            patch.object(release_ci.build, "_preflight_checks") as preflight,
+            patch.object(
+                release_ci.build,
+                "_get_github_release_assets",
+                return_value=remote_assets,
+            ),
+        ):
+            result = release_ci.prepare_release(
+                "2.21",
+                "正式发布 v2.21",
+                dry_run=True,
+                github_output=str(output),
+            )
+
+        assert result["resume"] == "true"
+        assert result["needs_windows"] == "false"
+        assert result["needs_macos"] == "false"
+        preflight.assert_called_once_with(require_clean=False, strict_changelog=True)
+        written = output.read_text(encoding="utf-8")
+        assert "release_sha=" + "a" * 40 in written
+        assert "needs_windows=false" in written
+        assert "needs_macos=false" in written
+
+
+def test_publish_exposes_release_only_after_both_stores_are_complete():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        notes_path = temp_path / "notes.md"
+        notes_path.write_text("notes", encoding="utf-8")
+        artifacts = [temp_path / name for name in release_ci.RELEASE_ARTIFACTS]
+        for artifact in artifacts:
+            artifact.write_bytes(b"artifact")
+        github_assets = {path.name: _asset(path.stat().st_size) for path in artifacts}
+        events: list[str] = []
+
+        with (
+            patch.object(release_ci, "_require_publish_secrets", return_value="token"),
+            patch.object(release_ci, "_git_text", return_value="a" * 40),
+            patch.object(release_ci, "_version_at_ref", return_value="2.21"),
+            patch.object(
+                release_ci,
+                "_fetch_and_assert_current_master_compatible",
+                side_effect=lambda *_: events.append("master_safe") or "a" * 40,
+            ),
+            patch.object(release_ci, "_ensure_gitee_remote"),
+            patch.object(
+                release_ci.build,
+                "_extract_changelog_release",
+                return_value=("v2.21 — Test", "### 新增功能\n\n- Test"),
+            ),
+            patch.object(release_ci, "_notes_file", return_value=notes_path),
+            patch.object(release_ci, "_ensure_origin_tag", side_effect=lambda *_: events.append("tag")),
+            patch.object(release_ci, "_ensure_gitee_tag", side_effect=lambda *_: events.append("gitee_tag")),
+            patch.object(
+                release_ci,
+                "_ensure_github_release",
+                side_effect=lambda *_: events.append("github_draft"),
+            ),
+            patch.object(release_ci, "_ensure_local_artifacts", return_value=artifacts),
+            patch.object(
+                release_ci,
+                "_upload_github_artifacts",
+                side_effect=lambda *_: events.append("github_assets") or github_assets,
+            ),
+            patch.object(
+                release_ci,
+                "_publish_gitee_artifacts",
+                side_effect=lambda *_: events.append("gitee_assets")
+                or release_ci._canonical_downloads_cn("2.21"),
+            ),
+            patch.object(
+                release_ci,
+                "_publish_github_release",
+                side_effect=lambda *_: events.append("github_public"),
+            ),
+            patch.object(
+                release_ci,
+                "_commit_and_sync_manifest",
+                side_effect=lambda *_: events.append("manifest") or "b" * 40,
+            ),
+            patch.object(
+                release_ci.build,
+                "_verify_release_remote_state",
+                side_effect=lambda *_: events.append("remote_verify") or True,
+            ),
+            patch.object(
+                release_ci,
+                "verify_public_endpoints",
+                side_effect=lambda *_: events.append("public_verify"),
+            ),
+        ):
+            release_ci.publish_release("2.21", "正式发布 v2.21", "a" * 40)
+
+        assert events.index("github_assets") < events.index("github_public")
+        assert events.index("gitee_assets") < events.index("github_public")
+        assert events.count("master_safe") == 2
+        assert events.index("gitee_assets") < events.index("master_safe", 1)
+        assert events.index("master_safe", 1) < events.index("github_public")
+        assert events.index("github_public") < events.index("manifest")
+        assert events[-2:] == ["remote_verify", "public_verify"]
+
+
+def test_gitee_ci_upload_accepts_windows_and_macos_artifacts_together():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        artifacts = [temp_path / name for name in release_ci.RELEASE_ARTIFACTS]
+        for artifact in artifacts:
+            artifact.write_bytes(b"artifact")
+        cache = {
+            "token": "token",
+            "owner": "owner",
+            "repo": "repo",
+            "tag": "v2.21",
+            "api_base": "https://example.invalid/api",
+            "release_id": 1,
+            "existing": {},
+        }
+
+        def fake_upload(path, *_args, **_kwargs):
+            return path.name, {
+                "browser_download_url": f"https://example.invalid/{path.name}"
+            }
+
+        with patch.object(
+            release_ci.build,
+            "_gitee_upload_single",
+            side_effect=fake_upload,
+        ):
+            downloads = release_ci.build._gitee_upload_artifacts(
+                "2.21",
+                "v2.21 — Test",
+                "notes",
+                artifacts,
+                release_cache=cache,
+                large_workers=1,
+            )
+
+        assert set(downloads) == {"windows", "macos", "macos_dmg"}
+
+
+def test_gitee_ci_upload_stops_after_the_first_failed_artifact():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        artifacts = [temp_path / name for name in release_ci.RELEASE_ARTIFACTS]
+        for artifact in artifacts:
+            artifact.write_bytes(b"artifact")
+        cache = {
+            "token": "token",
+            "owner": "owner",
+            "repo": "repo",
+            "tag": "v2.21",
+            "api_base": "https://example.invalid/api",
+            "release_id": 1,
+            "existing": {},
+        }
+        uploaded: list[str] = []
+
+        def fail_first(path, *_args, **_kwargs):
+            uploaded.append(path.name)
+            raise RuntimeError("upload failed")
+
+        with (
+            patch.object(
+                release_ci.build,
+                "_gitee_upload_single",
+                side_effect=fail_first,
+            ),
+            _raises(RuntimeError, "upload failed"),
+        ):
+            release_ci.build._gitee_upload_artifacts(
+                "2.21",
+                "v2.21 — Test",
+                "notes",
+                artifacts,
+                release_cache=cache,
+                large_workers=1,
+                fail_fast=True,
+            )
+
+        assert uploaded == ["BOSS_ResumeFilter.exe"]

--- a/tests/unit/test_release_ci.py
+++ b/tests/unit/test_release_ci.py
@@ -65,6 +65,14 @@ def test_prepare_reuses_complete_remote_artifacts_on_same_commit_resume():
             "BOSS_ResumeFilter.dmg": _asset(),
         }
         with (
+            patch.dict(
+                release_ci.os.environ,
+                {
+                    "GITHUB_ACTIONS": "true",
+                    "GITHUB_EVENT_NAME": "workflow_dispatch",
+                    "GITHUB_REF_NAME": "master",
+                },
+            ),
             patch.object(release_ci, "resolve_release_sha", return_value=("a" * 40, True)),
             patch.object(
                 release_ci.build,
@@ -93,6 +101,23 @@ def test_prepare_reuses_complete_remote_artifacts_on_same_commit_resume():
         assert "release_sha=" + "a" * 40 in written
         assert "needs_windows=false" in written
         assert "needs_macos=false" in written
+
+
+def test_prepare_rejects_non_manual_github_actions_event():
+    with patch.dict(
+        release_ci.os.environ,
+        {
+            "GITHUB_ACTIONS": "true",
+            "GITHUB_EVENT_NAME": "pull_request",
+            "GITHUB_REF_NAME": "master",
+        },
+    ):
+        with _raises(release_ci.ReleaseAutomationError, "只能由 workflow_dispatch 手动触发"):
+            release_ci.prepare_release(
+                "2.21",
+                "正式发布 v2.21",
+                dry_run=True,
+            )
 
 
 def test_publish_exposes_release_only_after_both_stores_are_complete():

--- a/tests/unit/test_update_integrity.py
+++ b/tests/unit/test_update_integrity.py
@@ -206,11 +206,14 @@ def test_release_asset_metadata_from_remote_assets_uses_github_digest():
 
 
 def test_release_workflow_only_runs_when_explicitly_dispatched():
-    """Local release owns tag publication; CI should not race it on tag push."""
+    """A master merge must never publish without the separate release authorization."""
     workflow = (build.BASE_DIR / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
 
     assert "workflow_dispatch:" in workflow
     assert "tags:" not in workflow
+    assert "pull_request:" not in workflow
+    assert "authorization:" in workflow
+    assert "scripts/release_ci.py publish" in workflow
 
 
 def test_gitee_sync_never_force_pushes_master():


### PR DESCRIPTION
## 变更内容

- 将正式发布改为仅允许手动 `workflow_dispatch`，并要求准确输入“正式发布 vX.Y”
- 严格门禁通过后并行构建 Windows 和 macOS 产物
- 自动完成 GitHub Draft Release、Gitee Release 镜像、`latest.json` 更新和线上验收
- 以版本和不可变发布提交为恢复依据，复用一致的 tag 和已验证附件
- 停用本地 `build.py --release` 正式发布入口，避免双控制面并发修改
- 同步项目规范、打包文档和专项回归测试

## 原因

原发布流程需要多次人工确认，并由本地发布机承担跨平台产物和 Gitee 中转。流程耗时长、容易停在半发布状态，也难以从失败步骤安全恢复。

## 开发与使用影响

- PR 合并仍是独立授权，合并 `master` 不会自动发布
- 后续只需一次“正式发布 vX.Y”授权即可启动完整发布流水线
- 任一关键步骤失败都会停止后续晋级；同一提交可安全重跑
- 本 PR 只修改发布能力，不发布新版本

## 验证

- `python tests/run_unit_tests.py`：931 项通过
- `python tests/test_import.py`：通过
- `python -m py_compile build.py scripts/release_ci.py tests/unit/test_release_ci.py`：通过
- v2.20 严格 Dry Run：通过，识别为断点续跑并复用双平台产物
- `git diff --check`：通过