### PR TITLE
修复多模型接入、弹窗布局与学历验证码识别

### DIFF
--- a/ai_adapter.py
+++ b/ai_adapter.py
@@ -36,7 +36,7 @@ OFFICIAL_API_ENDPOINT_RULES = {
         "docs_url": "https://api-docs.deepseek.com/",
     },
     "kimi": {
-        "exact_hosts": ("api.moonshot.ai", "api.moonshot.cn"),
+        "exact_hosts": ("api.moonshot.ai", "api.moonshot.cn", "api.kimi.com"),
         "service_name": "Kimi",
         "docs_url": "https://platform.kimi.ai/docs/api/overview",
     },
@@ -98,7 +98,9 @@ def classify_api_endpoint(api_config: dict) -> dict[str, Any]:
 
     service_name = str(rule.get("service_name") or provider or "未配置服务")
     if is_official:
-        if hostname == "token-plan.cn-beijing.maas.aliyuncs.com":
+        if provider == "kimi" and hostname == "api.kimi.com":
+            service_name = "Kimi Code"
+        elif hostname == "token-plan.cn-beijing.maas.aliyuncs.com":
             service_name = "阿里云百炼 Token Plan"
         elif hostname in {"coding.dashscope.aliyuncs.com", "coding-intl.dashscope.aliyuncs.com"}:
             service_name = "阿里云百炼 Coding Plan"
@@ -120,6 +122,20 @@ def classify_api_endpoint(api_config: dict) -> dict[str, Any]:
     }
 
 
+def normalize_api_base_url(api_config: dict) -> str:
+    """Normalize documented provider Base URLs without changing unknown relays."""
+    raw_url = str(api_config.get("base_url") or "").strip().rstrip("/")
+    provider = str(api_config.get("api_provider") or "").strip().lower()
+    parts = urlsplit(raw_url)
+    if (
+        provider == "kimi"
+        and (parts.hostname or "").lower() == "api.kimi.com"
+        and parts.path.rstrip("/") == "/coding"
+    ):
+        return urlunsplit((parts.scheme, parts.netloc, "/coding/v1", parts.query, parts.fragment))
+    return raw_url
+
+
 def detect_protocol(api_config: dict) -> str:
     """Return the wire protocol required by the configured endpoint."""
     provider = str(api_config.get("api_provider") or "").lower()
@@ -135,7 +151,7 @@ def capability_cache_key(api_config: dict) -> str:
     """Build a non-secret cache key scoped to endpoint and model."""
     return "|".join((
         detect_protocol(api_config),
-        str(api_config.get("base_url") or "").rstrip("/").lower(),
+        normalize_api_base_url(api_config).lower(),
         str(api_config.get("model") or "").strip().lower(),
     ))
 
@@ -183,7 +199,7 @@ def _append_query(url: str, key: str, value: str) -> str:
 
 
 def _azure_url(api_config: dict) -> str:
-    base_url = str(api_config.get("base_url") or "").rstrip("/")
+    base_url = normalize_api_base_url(api_config)
     if base_url.endswith("/chat/completions"):
         return _append_query(
             base_url,
@@ -213,7 +229,7 @@ def build_request(
 ) -> tuple[str, dict, dict, str]:
     """Build a provider-specific request with one normalized input shape."""
     protocol = detect_protocol(api_config)
-    base_url = str(api_config.get("base_url") or "").rstrip("/")
+    base_url = normalize_api_base_url(api_config)
     model = str(api_config.get("model") or "")
     if protocol == "anthropic":
         url = f"{base_url}/messages" if base_url.endswith("/v1") else f"{base_url}/v1/messages"
@@ -269,6 +285,9 @@ def build_request(
             }
     base_lower = base_url.lower()
     model_lower = model.lower()
+    if "api.kimi.com/coding" in base_lower:
+        # Kimi Code's OpenAI-compatible models currently only accept 1.
+        body["temperature"] = 1
     if "dashscope.aliyuncs.com" in base_lower and model_lower.startswith("qwen3.7"):
         body["enable_thinking"] = False
     if api_config.get("_disable_thinking") and "xiaomimimo.com" in base_lower:

--- a/ai_adapter.py
+++ b/ai_adapter.py
@@ -286,8 +286,9 @@ def build_request(
     base_lower = base_url.lower()
     model_lower = model.lower()
     if "api.kimi.com/coding" in base_lower:
-        # Kimi Code's OpenAI-compatible models currently only accept 1.
+        # Kimi Code accepts temperature=1 and prefers max_completion_tokens.
         body["temperature"] = 1
+        body["max_completion_tokens"] = body.pop("max_tokens")
     if "dashscope.aliyuncs.com" in base_lower and model_lower.startswith("qwen3.7"):
         body["enable_thinking"] = False
     if api_config.get("_disable_thinking") and "xiaomimimo.com" in base_lower:

--- a/ai_adapter.py
+++ b/ai_adapter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -14,6 +15,68 @@ from paths import BASE_DIR
 
 CAPABILITY_CACHE_PATH = BASE_DIR / ".storage" / "model_capabilities.json"
 DEFAULT_AZURE_API_VERSION = "2024-10-21"
+
+
+@dataclass(frozen=True)
+class EndpointCandidate:
+    """Documented model-list endpoint for one provider channel."""
+
+    channel: str
+    service_name: str
+    base_url: str
+    auth_style: str = "bearer"
+
+
+@dataclass(frozen=True)
+class EndpointResolution:
+    """Deterministic result of validating credentials against known endpoints."""
+
+    status: str
+    provider: str
+    channel: str = ""
+    service_name: str = ""
+    base_url: str = ""
+    models: tuple[str, ...] = ()
+    http_status: int | None = None
+    message: str = ""
+
+
+API_ENDPOINT_DISCOVERY_RULES: dict[str, tuple[EndpointCandidate, ...]] = {
+    "qwen": (
+        EndpointCandidate("qwen_cn", "阿里云百炼（中国）", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
+        EndpointCandidate("qwen_intl", "阿里云百炼（国际）", "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
+        EndpointCandidate("qwen_us", "阿里云百炼（美国）", "https://dashscope-us.aliyuncs.com/compatible-mode/v1"),
+    ),
+    "deepseek": (
+        EndpointCandidate("deepseek", "DeepSeek", "https://api.deepseek.com"),
+    ),
+    "kimi": (
+        EndpointCandidate("kimi_cn", "Kimi 开放平台（国内）", "https://api.moonshot.cn/v1"),
+        EndpointCandidate("kimi_global", "Kimi 开放平台（海外）", "https://api.moonshot.ai/v1"),
+        EndpointCandidate("kimi_code", "Kimi Code", "https://api.kimi.com/coding/v1"),
+    ),
+    "zhipu": (
+        EndpointCandidate("zhipu", "智谱开放平台", "https://open.bigmodel.cn/api/paas/v4"),
+    ),
+    "minimax": (
+        EndpointCandidate("minimax_cn", "MiniMax（国内）", "https://api.minimaxi.com/v1"),
+        EndpointCandidate("minimax_global", "MiniMax（海外）", "https://api.minimax.io/v1"),
+    ),
+    "xiaomi": (
+        EndpointCandidate("xiaomi", "小米 MiMo", "https://api.xiaomimimo.com/v1"),
+    ),
+    "stepfun": (
+        EndpointCandidate("stepfun", "阶跃星辰", "https://api.stepfun.com/v1"),
+    ),
+    "openai": (
+        EndpointCandidate("openai", "OpenAI", "https://api.openai.com/v1"),
+    ),
+    "anthropic": (
+        EndpointCandidate(
+            "anthropic", "Anthropic", "https://api.anthropic.com/v1", auth_style="anthropic"
+        ),
+    ),
+}
 
 # Official endpoint evidence is kept beside the matching rule so updates can be
 # reviewed against provider documentation instead of extending ad-hoc lists.
@@ -134,6 +197,199 @@ def normalize_api_base_url(api_config: dict) -> str:
     ):
         return urlunsplit((parts.scheme, parts.netloc, "/coding/v1", parts.query, parts.fragment))
     return raw_url
+
+
+def has_endpoint_discovery(provider: str) -> bool:
+    """Return whether a provider has documented endpoints safe to auto-probe."""
+    return str(provider or "").strip().lower() in API_ENDPOINT_DISCOVERY_RULES
+
+
+def model_catalog_cache_key(provider: str, base_url: str) -> str:
+    """Return an endpoint-scoped key for cached model catalog comparisons."""
+    normalized = normalize_api_base_url({
+        "api_provider": provider,
+        "base_url": base_url,
+    })
+    return f"{str(provider or '').strip().lower()}|{normalized.lower()}"
+
+
+def _candidate_headers(candidate: EndpointCandidate, api_key: str) -> dict[str, str]:
+    headers = {"User-Agent": USER_AGENT, "Connection": "close"}
+    if candidate.auth_style == "anthropic":
+        headers.update({
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        })
+    else:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+def _extract_model_ids(payload: Any) -> tuple[str, ...]:
+    if not isinstance(payload, dict):
+        return ()
+    raw_models = payload.get("data")
+    if raw_models is None:
+        raw_models = payload.get("models")
+    if not isinstance(raw_models, list):
+        return ()
+    models: list[str] = []
+    for item in raw_models:
+        model_id = item.get("id") if isinstance(item, dict) else item
+        model_id = str(model_id or "").strip()
+        if model_id:
+            models.append(model_id)
+    return tuple(dict.fromkeys(models))
+
+
+def _ordered_endpoint_candidates(
+    provider: str,
+    api_key: str,
+    preferred_base_url: str = "",
+) -> tuple[EndpointCandidate, ...]:
+    provider = str(provider or "").strip().lower()
+    candidates = list(API_ENDPOINT_DISCOVERY_RULES.get(provider, ()))
+    if provider == "kimi" and str(api_key or "").startswith("sk-kimi-"):
+        candidates.sort(key=lambda item: item.channel != "kimi_code")
+
+    preferred = normalize_api_base_url({
+        "api_provider": provider,
+        "base_url": preferred_base_url,
+    })
+    if preferred:
+        matched = next(
+            (item for item in candidates if item.base_url.rstrip("/") == preferred),
+            None,
+        )
+        if matched is not None:
+            candidates.remove(matched)
+            candidates.insert(0, matched)
+        else:
+            endpoint = classify_api_endpoint({
+                "api_provider": provider,
+                "base_url": preferred,
+            })
+            candidates.insert(0, EndpointCandidate(
+                "configured",
+                str(endpoint.get("service_name") or "当前配置"),
+                preferred,
+                auth_style="anthropic" if provider == "anthropic" else "bearer",
+            ))
+
+    deduped: list[EndpointCandidate] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        key = candidate.base_url.rstrip("/").lower()
+        if key not in seen:
+            seen.add(key)
+            deduped.append(candidate)
+    return tuple(deduped)
+
+
+def discover_api_endpoint(
+    provider: str,
+    api_key: str,
+    preferred_base_url: str = "",
+    *,
+    request_get=None,
+    timeout: tuple[int, int] = (5, 10),
+) -> EndpointResolution:
+    """Identify the credential channel through documented model-list endpoints.
+
+    Key prefixes only affect candidate order. A 200 response confirms the
+    endpoint; no inference request is made. Unknown providers are never probed.
+    """
+    provider = str(provider or "").strip().lower()
+    if not api_key:
+        return EndpointResolution("invalid", provider, message="API Key 为空")
+    candidates = _ordered_endpoint_candidates(provider, api_key, preferred_base_url)
+    if not candidates:
+        return EndpointResolution(
+            "unsupported", provider, message="该服务商没有可自动识别的官方端点"
+        )
+
+    if request_get is None:
+        import certifi
+        import requests
+
+        def request_get(url, **kwargs):
+            kwargs.setdefault("verify", certifi.where())
+            return requests.get(url, **kwargs)
+
+    transient: EndpointResolution | None = None
+    last_status: int | None = None
+    for candidate in candidates:
+        models_url = f"{candidate.base_url.rstrip('/')}/models"
+        try:
+            response = request_get(
+                models_url,
+                headers=_candidate_headers(candidate, api_key),
+                timeout=timeout,
+            )
+        except Exception as exc:
+            if transient is None:
+                transient = EndpointResolution(
+                    "unavailable",
+                    provider,
+                    candidate.channel,
+                    candidate.service_name,
+                    candidate.base_url,
+                    message=f"{type(exc).__name__}: {str(exc)[:120]}",
+                )
+            continue
+
+        status_code = int(getattr(response, "status_code", 0) or 0)
+        last_status = status_code
+        if status_code == 200:
+            try:
+                payload = response.json()
+            except (TypeError, ValueError):
+                payload = None
+            return EndpointResolution(
+                "confirmed",
+                provider,
+                candidate.channel,
+                candidate.service_name,
+                candidate.base_url,
+                _extract_model_ids(payload),
+                status_code,
+                "接入渠道和 API Key 已确认",
+            )
+        if status_code in (401, 403, 404):
+            continue
+        if status_code in (402, 429):
+            return EndpointResolution(
+                "probable",
+                provider,
+                candidate.channel,
+                candidate.service_name,
+                candidate.base_url,
+                http_status=status_code,
+                message=(
+                    "接入渠道可能已匹配，但会员状态异常"
+                    if status_code == 402
+                    else "接入渠道可能已匹配，但请求受到限流"
+                ),
+            )
+        if status_code >= 500 and transient is None:
+            transient = EndpointResolution(
+                "unavailable",
+                provider,
+                candidate.channel,
+                candidate.service_name,
+                candidate.base_url,
+                http_status=status_code,
+                message=f"服务暂时不可用（HTTP {status_code}）",
+            )
+
+    if transient is not None:
+        return transient
+    return EndpointResolution(
+        "invalid",
+        provider,
+        http_status=last_status,
+        message="API Key 与已登记的官方接入渠道均不匹配",
+    )
 
 
 def detect_protocol(api_config: dict) -> str:

--- a/ai_adapter.py
+++ b/ai_adapter.py
@@ -25,6 +25,8 @@ class EndpointCandidate:
     service_name: str
     base_url: str
     auth_style: str = "bearer"
+    key_prefixes: tuple[str, ...] = ()
+    public_catalog: bool = False
 
 
 @dataclass(frozen=True)
@@ -46,6 +48,20 @@ API_ENDPOINT_DISCOVERY_RULES: dict[str, tuple[EndpointCandidate, ...]] = {
         EndpointCandidate("qwen_cn", "阿里云百炼（中国）", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
         EndpointCandidate("qwen_intl", "阿里云百炼（国际）", "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
         EndpointCandidate("qwen_us", "阿里云百炼（美国）", "https://dashscope-us.aliyuncs.com/compatible-mode/v1"),
+        EndpointCandidate(
+            "qwen_token_plan",
+            "阿里云百炼 Token Plan",
+            "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+            key_prefixes=("sk-sp-",),
+            public_catalog=True,
+        ),
+        EndpointCandidate(
+            "qwen_coding_plan",
+            "阿里云百炼 Coding Plan",
+            "https://coding.dashscope.aliyuncs.com/v1",
+            key_prefixes=("sk-sp-",),
+            public_catalog=True,
+        ),
     ),
     "deepseek": (
         EndpointCandidate("deepseek", "DeepSeek", "https://api.deepseek.com"),
@@ -196,6 +212,18 @@ def normalize_api_base_url(api_config: dict) -> str:
         and parts.path.rstrip("/") == "/coding"
     ):
         return urlunsplit((parts.scheme, parts.netloc, "/coding/v1", parts.query, parts.fragment))
+    if (
+        provider == "qwen"
+        and (parts.hostname or "").lower() == "token-plan.cn-beijing.maas.aliyuncs.com"
+        and parts.path.rstrip("/") == "/v1"
+    ):
+        return urlunsplit((
+            parts.scheme,
+            parts.netloc,
+            "/compatible-mode/v1",
+            parts.query,
+            parts.fragment,
+        ))
     return raw_url
 
 
@@ -274,6 +302,14 @@ def _ordered_endpoint_candidates(
                 str(endpoint.get("service_name") or "当前配置"),
                 preferred,
                 auth_style="anthropic" if provider == "anthropic" else "bearer",
+                public_catalog=(
+                    provider == "qwen"
+                    and (urlsplit(preferred).hostname or "").lower() in {
+                        "token-plan.cn-beijing.maas.aliyuncs.com",
+                        "coding.dashscope.aliyuncs.com",
+                        "coding-intl.dashscope.aliyuncs.com",
+                    }
+                ),
             ))
 
     deduped: list[EndpointCandidate] = []
@@ -303,6 +339,10 @@ def discover_api_endpoint(
     if not api_key:
         return EndpointResolution("invalid", provider, message="API Key 为空")
     candidates = _ordered_endpoint_candidates(provider, api_key, preferred_base_url)
+    preferred = normalize_api_base_url({
+        "api_provider": provider,
+        "base_url": preferred_base_url,
+    })
     if not candidates:
         return EndpointResolution(
             "unsupported", provider, message="该服务商没有可自动识别的官方端点"
@@ -317,7 +357,9 @@ def discover_api_endpoint(
             return requests.get(url, **kwargs)
 
     transient: EndpointResolution | None = None
+    public_catalog_seen: EndpointResolution | None = None
     last_status: int | None = None
+    last_auth_status: int | None = None
     for candidate in candidates:
         models_url = f"{candidate.base_url.rstrip('/')}/models"
         try:
@@ -340,18 +382,38 @@ def discover_api_endpoint(
 
         status_code = int(getattr(response, "status_code", 0) or 0)
         last_status = status_code
+        if not candidate.public_catalog:
+            last_auth_status = status_code
         if status_code == 200:
             try:
                 payload = response.json()
             except (TypeError, ValueError):
                 payload = None
+            models = _extract_model_ids(payload)
+            if candidate.public_catalog:
+                public_catalog_seen = EndpointResolution(
+                    "catalog",
+                    provider,
+                    candidate.channel,
+                    candidate.service_name,
+                    candidate.base_url,
+                    models,
+                    status_code,
+                    "该渠道的模型目录无需认证，不能据此证明 API Key 有效",
+                )
+                prefix_matches = candidate.key_prefixes and any(
+                    str(api_key).startswith(prefix) for prefix in candidate.key_prefixes
+                )
+                if prefix_matches and candidate.base_url.rstrip("/") == preferred:
+                    return public_catalog_seen
+                continue
             return EndpointResolution(
                 "confirmed",
                 provider,
                 candidate.channel,
                 candidate.service_name,
                 candidate.base_url,
-                _extract_model_ids(payload),
+                models,
                 status_code,
                 "接入渠道和 API Key 已确认",
             )
@@ -384,10 +446,30 @@ def discover_api_endpoint(
 
     if transient is not None:
         return transient
+    preferred_host = (urlsplit(preferred).hostname or "").lower()
+    qwen_plan_hosts = {
+        "token-plan.cn-beijing.maas.aliyuncs.com",
+        "coding.dashscope.aliyuncs.com",
+        "coding-intl.dashscope.aliyuncs.com",
+    }
+    if (
+        public_catalog_seen is not None
+        and provider == "qwen"
+        and preferred_host in qwen_plan_hosts
+    ):
+        return EndpointResolution(
+            "invalid",
+            provider,
+            http_status=last_auth_status or last_status,
+            message=(
+                "当前地址是阿里云套餐专属渠道，但 API Key 不是其专属 sk-sp- Key，"
+                "并且也未通过百炼按量付费渠道认证；请检查 Key 类型和计费方案"
+            ),
+        )
     return EndpointResolution(
         "invalid",
         provider,
-        http_status=last_status,
+        http_status=last_auth_status or last_status,
         message="API Key 与已登记的官方接入渠道均不匹配",
     )
 

--- a/api_config.json
+++ b/api_config.json
@@ -1,11 +1,11 @@
 {
     "api_provider": "qwen",
-    "base_url": "https://token-plan.cn-beijing.maas.aliyuncs.com/v1",
+    "base_url": "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
     "model": "kimi-k2.6",
     "saved_models": [
         {
             "api_provider": "qwen",
-            "base_url": "https://token-plan.cn-beijing.maas.aliyuncs.com/v1",
+            "base_url": "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
             "model": "kimi-k2.6"
         }
     ],
@@ -14,7 +14,7 @@
     "llm_read_timeout": 60,
     "education_model_ref": {
         "api_provider": "qwen",
-        "base_url": "https://token-plan.cn-beijing.maas.aliyuncs.com/v1",
+        "base_url": "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
         "model": "kimi-k2.6"
     }
 }

--- a/education_certificate.py
+++ b/education_certificate.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import requests
-from PIL import Image, ImageOps
+from PIL import Image, ImageEnhance, ImageFilter, ImageOps
 
 from ai_adapter import build_request, detect_protocol, friendly_http_error, normalize_response
 
@@ -19,6 +19,7 @@ SUPPORTED_IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
 SUPPORTED_PDF_SUFFIXES = {".pdf"}
 MAX_IMAGE_SIDE = 1800
 JPEG_QUALITY = 88
+CAPTCHA_AUTO_SUBMIT_MIN_CONFIDENCE = 80
 CHSI_QUERY_URL = "https://www.chsi.com.cn/xlcx/lscx/query.do"
 XIAOMI_VISION_MODEL = "mimo-v2.5"
 
@@ -347,9 +348,14 @@ def _invoke_model(
         raise RuntimeError(friendly_http_error(response.status_code, response_payload))
     if not isinstance(response_payload, dict):
         raise RuntimeError("AI 服务返回了无效响应")
+    raw_final_content = True
+    if protocol != "anthropic":
+        raw_choice = (response_payload.get("choices") or [{}])[0]
+        raw_message = raw_choice.get("message") or {}
+        raw_final_content = bool(raw_message.get("content"))
     message, finish_reason = normalize_response(protocol, response_payload)
     content = str(message.get("content") or message.get("reasoning_content") or "")
-    if finish_reason == "length" and not message.get("content"):
+    if finish_reason == "length" and not raw_final_content:
         raise RuntimeError("AI 输出长度达到上限，未返回最终识别结果")
     return _extract_json_object(content)
 
@@ -595,13 +601,31 @@ return {
 
 
 def _image_bytes_to_data_url(raw_bytes: bytes) -> str:
-    """将原始图片字节转为适合视觉模型的 JPEG data URL。"""
+    """将小尺寸验证码放大增强后转为无损 PNG data URL。"""
     image = Image.open(io.BytesIO(raw_bytes)).convert("RGB")
+    width, height = image.size
+    if width <= 0 or height <= 0:
+        raise ValueError("验证码图片尺寸无效")
+    scale = 1
+    if width < 480 or height < 160:
+        scale = min(6, max(
+            4,
+            (480 + width - 1) // width,
+            (160 + height - 1) // height,
+        ))
+    if scale > 1:
+        image = image.resize(
+            (width * scale, height * scale),
+            Image.Resampling.LANCZOS,
+        )
     image.thumbnail((MAX_IMAGE_SIDE, MAX_IMAGE_SIDE), Image.Resampling.LANCZOS)
+    image = ImageOps.autocontrast(image, cutoff=1)
+    image = ImageEnhance.Contrast(image).enhance(1.35)
+    image = image.filter(ImageFilter.SHARPEN)
     buffer = io.BytesIO()
-    image.save(buffer, format="JPEG", quality=JPEG_QUALITY, optimize=True)
+    image.save(buffer, format="PNG", optimize=True)
     encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
-    return f"data:image/jpeg;base64,{encoded}"
+    return f"data:image/png;base64,{encoded}"
 
 
 def capture_captcha_image(page: Any) -> str:
@@ -687,12 +711,9 @@ def capture_captcha_image(page: Any) -> str:
                     if x2 > x1 and y2 > y1:
                         cropped = full_img.crop((x1, y1, x2, y2))
                         buf = io.BytesIO()
-                        cropped.convert("RGB").save(
-                            buf, format="JPEG", quality=JPEG_QUALITY, optimize=True
-                        )
-                        encoded = base64.b64encode(buf.getvalue()).decode("ascii")
+                        cropped.convert("RGB").save(buf, format="PNG", optimize=True)
                         full_path.unlink(missing_ok=True)
-                        return f"data:image/jpeg;base64,{encoded}"
+                        return _image_bytes_to_data_url(buf.getvalue())
         finally:
             full_path.unlink(missing_ok=True)
 
@@ -709,7 +730,15 @@ def recognize_captcha(
     """调用视觉模型识别验证码图片。返回 (captcha_type, answer, confidence)。"""
     vision_config = resolve_vision_api_config(api_config)
     messages = build_captcha_messages(vision_config, data_url)
-    parsed = _invoke_model(vision_config, api_key, messages, timeout=timeout)
+    base_url = str(vision_config.get("base_url") or "").lower()
+    max_tokens = 1024 if "api.kimi.com/coding" in base_url else 500
+    parsed = _invoke_model(
+        vision_config,
+        api_key,
+        messages,
+        timeout=timeout,
+        max_tokens=max_tokens,
+    )
     return parse_captcha_result(parsed)
 
 

--- a/education_certificate.py
+++ b/education_certificate.py
@@ -111,6 +111,8 @@ def likely_supports_vision(api_config: dict[str, Any]) -> bool:
     provider = str(api_config.get("api_provider") or "").lower()
     model = str(api_config.get("model") or "").lower()
     base_url = str(api_config.get("base_url") or "").lower()
+    if provider == "kimi" and model == "k3":
+        return True
     # 小米服务：mimo-v2.5 系列支持视觉
     if (
         provider == "xiaomi"
@@ -345,8 +347,10 @@ def _invoke_model(
         raise RuntimeError(friendly_http_error(response.status_code, response_payload))
     if not isinstance(response_payload, dict):
         raise RuntimeError("AI 服务返回了无效响应")
-    message, _finish_reason = normalize_response(protocol, response_payload)
+    message, finish_reason = normalize_response(protocol, response_payload)
     content = str(message.get("content") or message.get("reasoning_content") or "")
+    if finish_reason == "length" and not message.get("content"):
+        raise RuntimeError("AI 输出长度达到上限，未返回最终识别结果")
     return _extract_json_object(content)
 
 
@@ -362,7 +366,11 @@ def recognize_certificate_image(
     data_url = prepare_image_data_url(path)
     orientation_data_url = prepare_orientation_sheet_data_url(path)
     messages = build_vision_messages(vision_config, data_url, orientation_data_url)
-    parsed = _invoke_model(vision_config, api_key, messages, timeout=timeout)
+    base_url = str(vision_config.get("base_url") or "").lower()
+    max_tokens = 1024 if "api.kimi.com/coding" in base_url else 500
+    parsed = _invoke_model(
+        vision_config, api_key, messages, timeout=timeout, max_tokens=max_tokens,
+    )
     return normalize_recognition(parsed, str(vision_config.get("model") or ""))
 
 

--- a/gui_main.py
+++ b/gui_main.py
@@ -41,7 +41,13 @@ from candidate_state_diagnostics import (
     diagnose_candidate_states,
     summarize_candidate_state_diagnostics,
 )
-from ai_adapter import classify_api_endpoint, normalize_api_base_url
+from ai_adapter import (
+    classify_api_endpoint,
+    discover_api_endpoint,
+    has_endpoint_discovery,
+    model_catalog_cache_key,
+    normalize_api_base_url,
+)
 from greeting_failure import diagnose_greeting_failure, format_greeting_failure_message
 from contact_queue import (
     build_contact_queue_item,
@@ -2808,7 +2814,13 @@ class BossFilterGUI:
 
         # 获取模型列表按钮
         icon_download_models = self.icons.button('download', self.colors['text_primary'])
-        btn_fetch = ttk.Button(row2, image=icon_download_models, text=" 获取模型列表", compound=tk.LEFT, command=self.fetch_model_list)
+        btn_fetch = ttk.Button(
+            row2,
+            image=icon_download_models,
+            text=" 自动识别并获取模型",
+            compound=tk.LEFT,
+            command=self.fetch_model_list,
+        )
         btn_fetch._icon_ref = icon_download_models
         btn_fetch.pack(side="left")
 
@@ -8201,7 +8213,7 @@ class BossFilterGUI:
             messagebox.showwarning("警告", "请先输入 API Key")
             return
 
-        if not base_url:
+        if not base_url and not has_endpoint_discovery(provider):
             messagebox.showwarning("警告", "请先输入 Base URL")
             return
 
@@ -8214,29 +8226,57 @@ class BossFilterGUI:
             self.api_base_url_var.set(base_url)
 
         # 显示加载中状态（不使用 update()，避免重入）
-        self._update_api_status(text="⏳ 正在获取模型列表...", foreground=self.colors['warning'])
+        status_text = (
+            "⏳ 正在识别接入渠道并获取模型..."
+            if has_endpoint_discovery(provider)
+            else "⏳ 正在获取模型列表..."
+        )
+        self._update_api_status(text=status_text, foreground=self.colors['warning'])
 
         def fetch_thread():
+            nonlocal base_url
             try:
-                # 构建模型列表 API 端点
-                # 大部分服务商兼容 OpenAI 格式：GET /v1/models
-                models_url = f"{base_url.rstrip('/')}/models"
+                detected_service_name = ""
+                resolution_status = ""
+                if has_endpoint_discovery(provider):
+                    resolution = discover_api_endpoint(
+                        provider,
+                        api_key,
+                        preferred_base_url=base_url,
+                    )
+                    resolution_status = resolution.status
+                    response_status = resolution.http_status or 0
+                    response_text = resolution.message
+                    if resolution.status == "confirmed":
+                        base_url = resolution.base_url
+                        detected_service_name = resolution.service_name
+                        data = {"data": [{"id": model} for model in resolution.models]}
+                        response_status = 200
 
-                headers = {
-                    "Authorization": f"Bearer {api_key}",
-                    "User-Agent": USER_AGENT
-                }
+                        def _apply_resolution():
+                            self.api_base_url_var.set(base_url)
+                            self._verified_api_endpoint = (provider, api_key, base_url)
 
-                # 发送请求，超时 15 秒
-                response = requests.get(
-                    models_url,
-                    headers=headers,
-                    timeout=15,
-                    verify=certifi.where()
-                )
+                        self.root.after(0, _apply_resolution)
+                    else:
+                        data = {}
+                else:
+                    # 自定义/中转地址只验证用户明确输入的 URL，不自动枚举其他域名。
+                    models_url = f"{base_url.rstrip('/')}/models"
+                    response = requests.get(
+                        models_url,
+                        headers={
+                            "Authorization": f"Bearer {api_key}",
+                            "User-Agent": USER_AGENT,
+                        },
+                        timeout=15,
+                        verify=certifi.where(),
+                    )
+                    response_status = response.status_code
+                    response_text = response.text
+                    data = response.json() if response_status == 200 else {}
 
-                if response.status_code == 200:
-                    data = response.json()
+                if response_status == 200:
 
                     # 解析模型列表（兼容 OpenAI 格式）
                     raw_models = []
@@ -8272,7 +8312,21 @@ class BossFilterGUI:
 
                         # 对比上次获取的模型列表，找出新增和下线模型
                         fetched_models_map = self.api_config.get("fetched_models", {})
-                        previous_models = set(fetched_models_map.get(provider, []))
+                        catalog_key = model_catalog_cache_key(provider, base_url)
+                        # 兼容旧版仅按服务商保存的模型列表；新记录按端点隔离，
+                        # 避免 Kimi 开放平台与 Kimi Code 等渠道互报上下线。
+                        previous_catalog = fetched_models_map.get(catalog_key)
+                        if previous_catalog is None:
+                            configured_catalog_key = model_catalog_cache_key(
+                                provider,
+                                (self.api_config or {}).get("base_url", ""),
+                            )
+                            previous_catalog = (
+                                fetched_models_map.get(provider, [])
+                                if configured_catalog_key == catalog_key
+                                else []
+                            )
+                        previous_models = set(previous_catalog)
                         current_models = set(models)
                         new_models = current_models - previous_models
                         removed_models = previous_models - current_models
@@ -8280,7 +8334,7 @@ class BossFilterGUI:
                         # 更新已获取模型列表并持久化
                         if "fetched_models" not in self.api_config:
                             self.api_config["fetched_models"] = {}
-                        self.api_config["fetched_models"][provider] = models
+                        self.api_config["fetched_models"][catalog_key] = models
                         try:
                             with open(get_api_config_path(for_write=True), 'w', encoding='utf-8') as _f:
                                 json.dump(self._sanitize_config_for_save(self.api_config), _f, ensure_ascii=False, indent=4)
@@ -8695,7 +8749,8 @@ class BossFilterGUI:
                             self._status_clickable_labels.clear()
 
                             # 基础信息
-                            base_text = f"✓ 找到 {_total_count} 个模型"
+                            channel_text = f"已识别 {detected_service_name}，" if detected_service_name else ""
+                            base_text = f"✓ {channel_text}找到 {_total_count} 个模型"
                             if _new_count == 0 and _removed_count == 0:
                                 # 无变更，只显示基础信息
                                 self._update_api_status(
@@ -8777,7 +8832,7 @@ class BossFilterGUI:
                             "未找到模型",
                             f"API 返回的数据中没有模型列表\n\n响应内容：{json.dumps(data, ensure_ascii=False)[:500]}"
                         ))
-                elif response.status_code == 401:
+                elif not resolution_status and response_status == 401:
                     self.root.after(0, lambda: self._update_api_status(
                         text="✗ 认证失败",
                         foreground=self.colors['danger']
@@ -8786,7 +8841,7 @@ class BossFilterGUI:
                         "认证失败",
                         "API Key 无效或已过期\n\n请检查 API Key 是否正确"
                     ))
-                elif response.status_code == 404:
+                elif not resolution_status and response_status == 404:
                     self.root.after(0, lambda: self._update_api_status(
                         text="✗ 接口不存在",
                         foreground=self.colors['danger']
@@ -8800,14 +8855,19 @@ class BossFilterGUI:
                         f"• 参考服务商文档获取可用模型"
                     ))
                 else:
+                    is_temporary = resolution_status in ("probable", "unavailable")
+                    status_color = self.colors['warning'] if is_temporary else self.colors['danger']
+                    status_prefix = "!" if is_temporary else "✗"
                     self.root.after(0, lambda: self._update_api_status(
-                        text=f"✗ 请求失败 ({response.status_code})",
-                        foreground=self.colors['danger']
+                        text=f"{status_prefix} 请求失败 ({response_status or '未确认'})",
+                        foreground=status_color,
                     ))
-                    self.root.after(0, lambda: messagebox.showerror(
-                        "请求失败",
-                        f"HTTP 状态码：{response.status_code}\n\n"
-                        f"响应：{response.text[:300]}"
+                    dialog = messagebox.showwarning if is_temporary else messagebox.showerror
+                    self.root.after(0, lambda s=response_status, m=response_text, d=dialog: d(
+                        "自动识别暂未完成" if is_temporary else (
+                            "自动识别失败" if has_endpoint_discovery(provider) else "请求失败"
+                        ),
+                        (f"HTTP 状态码：{s}\n\n" if s else "") + str(m)[:300],
                     ))
 
             except requests.exceptions.Timeout:

--- a/gui_main.py
+++ b/gui_main.py
@@ -8247,7 +8247,7 @@ class BossFilterGUI:
                     resolution_status = resolution.status
                     response_status = resolution.http_status or 0
                     response_text = resolution.message
-                    if resolution.status == "confirmed":
+                    if resolution.status in ("confirmed", "catalog") and resolution.models:
                         base_url = resolution.base_url
                         detected_service_name = resolution.service_name
                         data = {"data": [{"id": model} for model in resolution.models]}
@@ -8255,7 +8255,8 @@ class BossFilterGUI:
 
                         def _apply_resolution():
                             self.api_base_url_var.set(base_url)
-                            self._verified_api_endpoint = (provider, api_key, base_url)
+                            if resolution.status == "confirmed":
+                                self._verified_api_endpoint = (provider, api_key, base_url)
 
                         self.root.after(0, _apply_resolution)
                     else:
@@ -8750,7 +8751,8 @@ class BossFilterGUI:
 
                             # 基础信息
                             channel_text = f"已识别 {detected_service_name}，" if detected_service_name else ""
-                            base_text = f"✓ {channel_text}找到 {_total_count} 个模型"
+                            verification_text = "；API Key 待测试连接" if resolution_status == "catalog" else ""
+                            base_text = f"✓ {channel_text}找到 {_total_count} 个模型{verification_text}"
                             if _new_count == 0 and _removed_count == 0:
                                 # 无变更，只显示基础信息
                                 self._update_api_status(

--- a/gui_main.py
+++ b/gui_main.py
@@ -5052,58 +5052,35 @@ class BossFilterGUI:
                             self._update_education_queue_row(iid)
                     self.run_on_ui(_update)
 
-                max_retries = 2
-                for attempt in range(max_retries + 1):
-                    try:
-                        on_progress("正在加载学信网页面...", "")
-                        success, status = self._fill_and_solve_captcha(
-                            page, n, cn, on_progress=on_progress,
-                        )
-                        # 如果成功或不是验证码错误，跳出重试循环
-                        if success or status != "识别失败":
-                            break
-                        # 验证码错误，准备重试
-                        if attempt < max_retries:
-                            with self._education_browser_lock:
-                                # 点击验证码图片刷新
-                                try:
-                                    page.run_js("""
-                                    const input = document.querySelector('input[name="yzm"]');
-                                    if (input) {
-                                      const selectors = [
-                                        '.yzm-box', '.captcha-box', '.verify-img', '.imgCode'
-                                      ];
-                                      for (const sel of selectors) {
-                                        const c = input.closest(sel);
-                                        if (c) {
-                                          const img = c.querySelector('img');
-                                          if (img) { img.click(); break; }
-                                        }
-                                      }
-                                    }
-                                    """)
-                                except Exception:
-                                    pass
-                            time.sleep(2)
-                    except Exception as error:
-                        error_text = str(error)
-                        self._log_education_error("打开学信网", error, iid)
-                        def show_error(iid=iid, err=error_text):
-                            queue_item = self.education_items.get(iid)
-                            if not queue_item:
-                                return
-                            queue_item["status"] = "打开失败"
-                            error_line = err.splitlines()[0] if err else "未知错误"
-                            queue_item["detail"] = f"打开学信网失败：{error_line}"
-                            queue_item["warnings"] = err
-                            self._update_education_queue_row(iid)
-                            if self.education_current_id == iid:
-                                self.education_status_var.set(queue_item["detail"])
-                                self.education_warning_var.set(err)
-                            self._set_captcha_btn_state("normal")
-                            self._restore_education_fill_button_if_done()
-                        self.run_on_ui(show_error)
-                        return  # 异常退出重试循环
+                max_attempts = 3
+                try:
+                    on_progress("正在加载学信网页面...", "")
+                    success, status = self._fill_and_solve_captcha(
+                        page,
+                        n,
+                        cn,
+                        on_progress=on_progress,
+                        max_attempts=max_attempts,
+                    )
+                except Exception as error:
+                    error_text = str(error)
+                    self._log_education_error("打开学信网", error, iid)
+                    def show_error(iid=iid, err=error_text):
+                        queue_item = self.education_items.get(iid)
+                        if not queue_item:
+                            return
+                        queue_item["status"] = "打开失败"
+                        error_line = err.splitlines()[0] if err else "未知错误"
+                        queue_item["detail"] = f"打开学信网失败：{error_line}"
+                        queue_item["warnings"] = err
+                        self._update_education_queue_row(iid)
+                        if self.education_current_id == iid:
+                            self.education_status_var.set(queue_item["detail"])
+                            self.education_warning_var.set(err)
+                        self._set_captcha_btn_state("normal")
+                        self._restore_education_fill_button_if_done()
+                    self.run_on_ui(show_error)
+                    return
                 # 显示最终结果
                 def show_success(iid=iid, ok=success, st=status):
                     queue_item = self.education_items.get(iid)
@@ -5115,7 +5092,7 @@ class BossFilterGUI:
                         queue_item["warnings"] = "验证码通过后按页面提示使用手机扫码。"
                     elif st == "识别失败":
                         queue_item["status"] = "识别失败"
-                        queue_item["detail"] = f"验证码识别错误（已重试 {max_retries} 次），请点击「重新识别验证码」重试。"
+                        queue_item["detail"] = f"验证码识别错误（已尝试 {max_attempts} 次），请点击「重新识别验证码」重试。"
                         queue_item["warnings"] = ""
                     else:
                         queue_item["status"] = "待人工验证"
@@ -5174,8 +5151,9 @@ class BossFilterGUI:
     def _fill_and_solve_captcha(
         self, page, name: str, certificate_number: str,
         on_progress: "Callable[[str, str], None] | None" = None,
+        max_attempts: int = 3,
     ) -> tuple[bool, str]:
-        """填写表单 + 截取验证码 + AI 识别 + 填入 + 查询。
+        """填写表单并最多三次识别、提交新的验证码。
 
         on_progress(detail, status): 每个阶段完成时回调，用于实时更新 GUI 状态。
 
@@ -5185,18 +5163,40 @@ class BossFilterGUI:
         - (False, "待人工验证"): 识别过程失败，需人工输入
         """
         from education_certificate import fill_chsi_query_page, navigate_to_chsi
+        import time
+
         _emit = on_progress or (lambda *_: None)
-        try:
-            # 页面导航在锁外执行，各 tab 并行加载（3-8 秒网络 I/O）
-            navigate_to_chsi(page)
-            _emit("正在填写表单...", "正在填写姓名和证书编号")
-            with self._education_browser_lock:
-                # 仅 JS 注入在锁内（<100ms）
-                fill_chsi_query_page(page, name, certificate_number, skip_navigation=True)
-            return self._attempt_captcha_solve(page, on_progress=on_progress)
-        except Exception as e:
-            print(f"[验证码识别] 失败：{e}")
-            return False, "待人工验证"
+        attempts = max(1, int(max_attempts))
+        last_status = "待人工验证"
+        for attempt in range(1, attempts + 1):
+            try:
+                if attempt > 1:
+                    _emit(
+                        f"正在重试验证码（{attempt}/{attempts}）...",
+                        "正在获取新的验证码",
+                    )
+                # 每次重新进入查询页，确保验证码已刷新且表单状态可预测。
+                navigate_to_chsi(page)
+                _emit("正在填写表单...", "正在填写姓名和证书编号")
+                with self._education_browser_lock:
+                    fill_chsi_query_page(
+                        page,
+                        name,
+                        certificate_number,
+                        skip_navigation=True,
+                    )
+                success, last_status = self._attempt_captcha_solve(
+                    page,
+                    on_progress=on_progress,
+                )
+                if success:
+                    return True, last_status
+            except Exception as error:
+                print(f"[验证码识别] 第 {attempt}/{attempts} 次失败：{error}")
+                last_status = "待人工验证"
+            if attempt < attempts:
+                time.sleep(1)
+        return False, last_status
 
     def _attempt_captcha_solve(
         self, page, *, on_progress: "Callable[[str, str], None] | None" = None,
@@ -5211,6 +5211,7 @@ class BossFilterGUI:
         - (False, "待人工验证"): 识别过程失败
         """
         from education_certificate import (
+            CAPTCHA_AUTO_SUBMIT_MIN_CONFIDENCE,
             capture_captcha_image, click_chsi_query_button,
             fill_captcha_answer, recognize_captcha,
             resolve_vision_api_config,
@@ -5242,6 +5243,12 @@ class BossFilterGUI:
             return False, "待人工验证"
 
         if captcha_type == "unknown" or not answer:
+            return False, "待人工验证"
+        if confidence < CAPTCHA_AUTO_SUBMIT_MIN_CONFIDENCE:
+            print(
+                f"[验证码识别] 置信度 {confidence} 低于自动提交门槛 "
+                f"{CAPTCHA_AUTO_SUBMIT_MIN_CONFIDENCE}，本次不提交并继续重试"
+            )
             return False, "待人工验证"
 
         # 阶段 3：填入答案 + 点击查询（重新获取浏览器锁）
@@ -5302,28 +5309,7 @@ class BossFilterGUI:
             def worker(iid=item_id):
                 try:
                     page = self._get_education_tab(iid)
-                    # 点击验证码图片刷新（避免识别旧验证码）— 需要浏览器锁
-                    try:
-                        with self._education_browser_lock:
-                            page.run_js("""
-                            const input = document.querySelector('input[name="yzm"]');
-                            if (input) {
-                              const selectors = [
-                                '.yzm-box', '.captcha-box', '.verify-img', '.imgCode'
-                              ];
-                              for (const sel of selectors) {
-                                const c = input.closest(sel);
-                                if (c) {
-                                  const img = c.querySelector('img');
-                                  if (img) { img.click(); break; }
-                                }
-                              }
-                            }
-                            """)
-                        import time
-                        time.sleep(1)
-                    except Exception:
-                        pass
+                    item = self.education_items.get(iid) or {}
                     def _retry_progress(status_text: str, detail: str, iid=iid):
                         def _update(iid=iid, s=status_text, d=detail):
                             item = self.education_items.get(iid)
@@ -5332,8 +5318,12 @@ class BossFilterGUI:
                                 item["detail"] = d
                                 self._update_education_queue_row(iid)
                         self.run_on_ui(_update)
-                    success, status = self._attempt_captcha_solve(
-                        page, on_progress=_retry_progress,
+                    success, status = self._fill_and_solve_captcha(
+                        page,
+                        str(item.get("name") or ""),
+                        str(item.get("certificate_number") or ""),
+                        on_progress=_retry_progress,
+                        max_attempts=3,
                     )
                     def show_result(iid=iid, ok=success, st=status):
                         item = self.education_items.get(iid)
@@ -5344,11 +5334,11 @@ class BossFilterGUI:
                                 item["warnings"] = "验证码通过后按页面提示使用手机扫码。"
                             elif st == "识别失败":
                                 item["status"] = "识别失败"
-                                item["detail"] = "验证码识别错误，请再次点击「重新识别验证码」重试。"
+                                item["detail"] = "验证码连续 3 次识别错误，请再次点击「重新识别验证码」重试。"
                                 item["warnings"] = ""
                             else:
                                 item["status"] = "待人工验证"
-                                item["detail"] = "验证码自动识别失败，请人工输入。"
+                                item["detail"] = "验证码连续 3 次自动识别失败，请人工输入。"
                                 item["warnings"] = ""
                             self._update_education_queue_row(iid)
                             if self.education_current_id == iid:

--- a/gui_main.py
+++ b/gui_main.py
@@ -41,7 +41,7 @@ from candidate_state_diagnostics import (
     diagnose_candidate_states,
     summarize_candidate_state_diagnostics,
 )
-from ai_adapter import classify_api_endpoint
+from ai_adapter import classify_api_endpoint, normalize_api_base_url
 from greeting_failure import diagnose_greeting_failure, format_greeting_failure_message
 from contact_queue import (
     build_contact_queue_item,
@@ -119,6 +119,7 @@ PROVIDER_DISPLAY = {
     "custom": "自定义 (Custom)"
 }
 DISPLAY_TO_KEY = {v: k for k, v in PROVIDER_DISPLAY.items()}
+KIMI_CODE_MODEL_IDS = {"kimi-for-coding", "kimi-for-coding-highspeed"}
 
 
 def _api_service_display_name(api_config: dict) -> str:
@@ -1074,9 +1075,9 @@ class BossFilterGUI:
         self.font_log = (FONT_FAMILY, int(11 * page_fs))
         self.font_table = (FONT_FAMILY, int(12 * page_fs))  # 表格字体
         messagebox.set_ui_fonts(
-            headline=(FONT_FAMILY, self.font_label[1], 'bold'),
-            message=self.font_label,
-            button=self.font_label,
+            headline=(FONT_FAMILY, max(10, self.font_log[1] + 1), 'bold'),
+            message=(FONT_FAMILY, max(10, self.font_log[1])),
+            button=(FONT_FAMILY, max(10, self.font_log[1])),
         )
 
         # 设置 Combobox 下拉列表字体（与 font_label 保持一致）
@@ -7977,6 +7978,28 @@ class BossFilterGUI:
                 messagebox.showwarning("警告", "请输入 Base URL")
                 return
 
+            normalized_base_url = normalize_api_base_url({
+                "api_provider": provider,
+                "base_url": base_url,
+            })
+            if normalized_base_url != base_url.rstrip("/"):
+                base_url = normalized_base_url
+                self.api_base_url_var.set(base_url)
+            if (
+                provider == "kimi"
+                and urlparse(base_url).hostname == "api.kimi.com"
+                and model_name not in KIMI_CODE_MODEL_IDS
+                and not pending
+            ):
+                messagebox.showwarning(
+                    "模型名称不正确",
+                    "Kimi Code 只接受以下模型 ID：\n\n"
+                    "• kimi-for-coding\n"
+                    "• kimi-for-coding-highspeed\n\n"
+                    "请修改模型名称，或先获取模型列表后选择。",
+                )
+                return
+
             # 按服务商 + Base URL 组合存储 API Key（区分同一服务商的不同接入方式）
             save_api_key(provider, api_key, base_url)
 
@@ -8186,7 +8209,8 @@ class BossFilterGUI:
 
         api_key = self.api_key_var.get().strip()
         base_url = self.api_base_url_var.get().strip()
-        provider = self.api_provider_var.get()
+        provider_display = self.api_provider_var.get().strip()
+        provider = self.DISPLAY_TO_KEY.get(provider_display, provider_display)
 
         if not api_key:
             messagebox.showwarning("警告", "请先输入 API Key")
@@ -8195,6 +8219,14 @@ class BossFilterGUI:
         if not base_url:
             messagebox.showwarning("警告", "请先输入 Base URL")
             return
+
+        normalized_base_url = normalize_api_base_url({
+            "api_provider": provider,
+            "base_url": base_url,
+        })
+        if normalized_base_url != base_url.rstrip("/"):
+            base_url = normalized_base_url
+            self.api_base_url_var.set(base_url)
 
         # 显示加载中状态（不使用 update()，避免重入）
         self._update_api_status(text="⏳ 正在获取模型列表...", foreground=self.colors['warning'])
@@ -8846,6 +8878,8 @@ class BossFilterGUI:
         api_key = self.api_key_var.get().strip()
         base_url = self.api_base_url_var.get().strip()
         model = self.api_model_var.get().strip()
+        provider_display = self.api_provider_var.get().strip()
+        provider_key = self.DISPLAY_TO_KEY.get(provider_display, provider_display)
 
         if not api_key:
             messagebox.showwarning("警告", "请先输入 API Key")
@@ -8857,6 +8891,26 @@ class BossFilterGUI:
 
         if not model:
             messagebox.showwarning("警告", "请先输入模型名称")
+            return
+
+
+        normalized_base_url = normalize_api_base_url({
+            "api_provider": provider_key,
+            "base_url": base_url,
+        })
+        if normalized_base_url != base_url.rstrip("/"):
+            base_url = normalized_base_url
+            self.api_base_url_var.set(base_url)
+        if (
+            provider_key == "kimi"
+            and urlparse(base_url).hostname == "api.kimi.com"
+            and model not in KIMI_CODE_MODEL_IDS
+        ):
+            messagebox.showwarning(
+                "模型名称不正确",
+                "当前是 Kimi Code 接口，模型名称应填写：\n\n"
+                "kimi-for-coding\n或 kimi-for-coding-highspeed",
+            )
             return
 
         # 显示测试中状态
@@ -8896,8 +8950,6 @@ class BossFilterGUI:
             # 连通不等于可用：真实验证该模型能否生成程序可解析的评估结果。
             try:
                 from llm_eval import probe_model_compatibility
-                provider_display = self.api_provider_var.get().strip()
-                provider_key = self.DISPLAY_TO_KEY.get(provider_display, provider_display)
                 capability = probe_model_compatibility({
                     "api_provider": provider_key,
                     "base_url": base_url,
@@ -8923,12 +8975,12 @@ class BossFilterGUI:
                 else:
                     error_message = capability.get("message", "模型无法生成程序所需评估格式")
                     self.root.after(0, lambda: self._update_api_status(
-                        text="✗ 模型不兼容",
+                        text="✗ 验证未通过",
                         foreground=self.colors['danger'],
                     ))
                     self.root.after(0, lambda: messagebox.showerror(
                         "连接测试失败",
-                        f"API 可访问，但模型不能用于 AI 评估\n\n原因：{error_message}",
+                        f"模型连接或兼容性验证未通过\n\n原因：{error_message}",
                     ))
                 return
             except Exception as e:

--- a/gui_main.py
+++ b/gui_main.py
@@ -119,7 +119,6 @@ PROVIDER_DISPLAY = {
     "custom": "自定义 (Custom)"
 }
 DISPLAY_TO_KEY = {v: k for k, v in PROVIDER_DISPLAY.items()}
-KIMI_CODE_MODEL_IDS = {"kimi-for-coding", "kimi-for-coding-highspeed"}
 
 
 def _api_service_display_name(api_config: dict) -> str:
@@ -1074,10 +1073,11 @@ class BossFilterGUI:
         self.font_stat_label = (FONT_FAMILY, int(15 * page_fs))
         self.font_log = (FONT_FAMILY, int(11 * page_fs))
         self.font_table = (FONT_FAMILY, int(12 * page_fs))  # 表格字体
+        modal_font_size = max(9, self.font_log[1] - 1)
         messagebox.set_ui_fonts(
-            headline=(FONT_FAMILY, max(10, self.font_log[1] + 1), 'bold'),
-            message=(FONT_FAMILY, max(10, self.font_log[1])),
-            button=(FONT_FAMILY, max(10, self.font_log[1])),
+            headline=(FONT_FAMILY, max(10, self.font_log[1]), 'bold'),
+            message=(FONT_FAMILY, modal_font_size),
+            button=(FONT_FAMILY, modal_font_size),
         )
 
         # 设置 Combobox 下拉列表字体（与 font_label 保持一致）
@@ -7985,21 +7985,6 @@ class BossFilterGUI:
             if normalized_base_url != base_url.rstrip("/"):
                 base_url = normalized_base_url
                 self.api_base_url_var.set(base_url)
-            if (
-                provider == "kimi"
-                and urlparse(base_url).hostname == "api.kimi.com"
-                and model_name not in KIMI_CODE_MODEL_IDS
-                and not pending
-            ):
-                messagebox.showwarning(
-                    "模型名称不正确",
-                    "Kimi Code 只接受以下模型 ID：\n\n"
-                    "• kimi-for-coding\n"
-                    "• kimi-for-coding-highspeed\n\n"
-                    "请修改模型名称，或先获取模型列表后选择。",
-                )
-                return
-
             # 按服务商 + Base URL 组合存储 API Key（区分同一服务商的不同接入方式）
             save_api_key(provider, api_key, base_url)
 
@@ -8901,18 +8886,6 @@ class BossFilterGUI:
         if normalized_base_url != base_url.rstrip("/"):
             base_url = normalized_base_url
             self.api_base_url_var.set(base_url)
-        if (
-            provider_key == "kimi"
-            and urlparse(base_url).hostname == "api.kimi.com"
-            and model not in KIMI_CODE_MODEL_IDS
-        ):
-            messagebox.showwarning(
-                "模型名称不正确",
-                "当前是 Kimi Code 接口，模型名称应填写：\n\n"
-                "kimi-for-coding\n或 kimi-for-coding-highspeed",
-            )
-            return
-
         # 显示测试中状态
         self._update_api_status(text="⏳ 正在验证...", foreground=self.colors['warning'])
 

--- a/gui_main.py
+++ b/gui_main.py
@@ -3208,6 +3208,18 @@ class BossFilterGUI:
         model_name = model_ref.get("model", "") or "未配置"
         return f"{role_label}（{provider_display} / {model_name}）"
 
+    def _assigned_model_test_roles(self, role, model_ref=None):
+        """返回一次测试应同步的用途；实际连接身份相同时双向同步。"""
+        if role not in ("default", "education"):
+            return (role,)
+        model_ref = model_ref or self._get_assigned_model_ref(role)
+        if all(
+            self._model_ref_matches(model_ref, self._get_assigned_model_ref(target_role))
+            for target_role in ("default", "education")
+        ):
+            return ("default", "education")
+        return (role,)
+
     def _set_assigned_model_test_state(self, role, state):
         """更新用途模型的红绿灯和行内状态。"""
         states = getattr(self, "_assigned_model_test_states", None)
@@ -7444,10 +7456,12 @@ class BossFilterGUI:
     def _test_assigned_model(self, role):
         """复用模型库连通性测试，测试指定用途当前实际使用的模型。"""
         model_ref = self._get_assigned_model_ref(role)
-        self._assigned_model_test_tokens[role] += 1
+        synced_roles = self._assigned_model_test_roles(role, model_ref)
+        for target_role in synced_roles:
+            self._assigned_model_test_tokens[target_role] += 1
+            self._assigned_model_test_refs[target_role] = dict(model_ref)
+            self._set_assigned_model_test_state(target_role, "testing")
         test_token = self._assigned_model_test_tokens[role]
-        self._assigned_model_test_refs[role] = dict(model_ref)
-        self._set_assigned_model_test_state(role, "testing")
         self._update_api_status(
             text=f"正在测试{self._assigned_model_test_target_label(role, model_ref)}...",
             foreground=self.colors['warning'],
@@ -7469,7 +7483,8 @@ class BossFilterGUI:
                     assigned_test_token=test_token,
                 )
                 return
-        self._set_assigned_model_test_state(role, "error")
+        for target_role in synced_roles:
+            self._set_assigned_model_test_state(target_role, "error")
         messagebox.showwarning("模型未保存", "当前模型不在已保存模型列表中，请先保存模型配置。")
 
     def _set_education_model(self):
@@ -7915,7 +7930,11 @@ class BossFilterGUI:
         if not hasattr(self, "_assigned_model_test_results"):
             self._assigned_model_test_results = {}
         self._assigned_model_test_results[self._model_ref_key(expected_ref)] = state
-        self._set_assigned_model_test_state(role, state)
+        for target_role in self._assigned_model_test_roles(role, expected_ref):
+            if self._model_ref_matches(
+                expected_ref, self._get_assigned_model_ref(target_role)
+            ):
+                self._set_assigned_model_test_state(target_role, state)
 
     def _save_capability_to_model(
         self, model_name, capability, provider_key=None, base_url=None, refresh=True

--- a/tests/unit/test_ai_adapter.py
+++ b/tests/unit/test_ai_adapter.py
@@ -6,6 +6,7 @@ from ai_adapter import (
     build_request,
     classify_api_endpoint,
     detect_protocol,
+    normalize_api_base_url,
     normalize_response,
 )
 
@@ -46,6 +47,7 @@ def test_official_endpoint_classification_uses_provider_and_documented_host():
         ("qwen", "https://workspace.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"),
         ("deepseek", "https://api.deepseek.com"),
         ("kimi", "https://api.moonshot.ai/v1"),
+        ("kimi", "https://api.kimi.com/coding/v1"),
         ("zhipu", "https://open.bigmodel.cn/api/paas/v4"),
         ("minimax", "https://api.minimax.io/v1"),
         ("minimax", "https://api.minimaxi.com/v1"),
@@ -93,6 +95,27 @@ def test_endpoint_classification_identifies_official_plan_channels():
     assert token_plan["service_name"] == "阿里云百炼 Token Plan"
     assert glm_coding["service_name"] == "智谱 GLM Coding Plan"
     assert step_plan["service_name"] == "阶跃星辰 Step Plan"
+
+
+def test_kimi_code_base_url_is_normalized_for_openai_compatible_requests():
+    config = {
+        "api_provider": "kimi",
+        "base_url": "https://api.kimi.com/coding/",
+        "model": "kimi-for-coding",
+    }
+
+    assert normalize_api_base_url(config) == "https://api.kimi.com/coding/v1"
+    url, _headers, body, protocol = build_request(
+        config,
+        "secret",
+        MESSAGES,
+        max_tokens=100,
+        temperature=0,
+    )
+
+    assert protocol == "openai_compatible"
+    assert url == "https://api.kimi.com/coding/v1/chat/completions"
+    assert body["temperature"] == 1
 
 
 def test_build_openai_compatible_request():

--- a/tests/unit/test_ai_adapter.py
+++ b/tests/unit/test_ai_adapter.py
@@ -116,6 +116,8 @@ def test_kimi_code_base_url_is_normalized_for_openai_compatible_requests():
     assert protocol == "openai_compatible"
     assert url == "https://api.kimi.com/coding/v1/chat/completions"
     assert body["temperature"] == 1
+    assert body["max_completion_tokens"] == 100
+    assert "max_tokens" not in body
 
 
 def test_build_openai_compatible_request():

--- a/tests/unit/test_ai_adapter.py
+++ b/tests/unit/test_ai_adapter.py
@@ -241,6 +241,63 @@ def test_kimi_code_base_url_is_normalized_for_openai_compatible_requests():
     assert "max_tokens" not in body
 
 
+def test_legacy_qwen_token_plan_base_url_is_normalized():
+    assert normalize_api_base_url({
+        "api_provider": "qwen",
+        "base_url": "https://token-plan.cn-beijing.maas.aliyuncs.com/v1/",
+    }) == "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
+
+
+def test_qwen_token_plan_public_catalog_does_not_authenticate_standard_key():
+    calls = []
+
+    def fake_get(url, **_kwargs):
+        calls.append(url)
+        if "token-plan.cn-beijing" in url:
+            return FakeResponse(200, {"data": [{"id": "kimi-k2.6"}]})
+        return FakeResponse(401, {"error": {"message": "invalid"}})
+
+    result = discover_api_endpoint(
+        "qwen",
+        "sk-standard-key",
+        preferred_base_url="https://token-plan.cn-beijing.maas.aliyuncs.com/v1",
+        request_get=fake_get,
+    )
+
+    assert result.status == "invalid"
+    assert result.http_status == 401
+    assert "不是其专属 sk-sp- Key" in result.message
+    assert calls[0] == (
+        "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1/models"
+    )
+    assert any("dashscope.aliyuncs.com/compatible-mode/v1/models" in url for url in calls)
+
+
+def test_qwen_token_plan_key_prefix_identifies_public_catalog_without_claiming_auth():
+    calls = []
+
+    def fake_get(url, **_kwargs):
+        calls.append(url)
+        return FakeResponse(200, {"data": [{"id": "kimi-k2.6"}]})
+
+    result = discover_api_endpoint(
+        "qwen",
+        "sk-sp-secret",
+        preferred_base_url=(
+            "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
+        ),
+        request_get=fake_get,
+    )
+
+    assert result.status == "catalog"
+    assert result.channel == "qwen_token_plan"
+    assert result.models == ("kimi-k2.6",)
+    assert "不能据此证明 API Key 有效" in result.message
+    assert calls == [
+        "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1/models"
+    ]
+
+
 def test_build_openai_compatible_request():
     url, headers, body, protocol = build_request(
         {"base_url": "https://api.example.com/v1", "model": "model-a"},

--- a/tests/unit/test_ai_adapter.py
+++ b/tests/unit/test_ai_adapter.py
@@ -2,10 +2,14 @@
 import json
 
 from ai_adapter import (
+    API_ENDPOINT_DISCOVERY_RULES,
     OFFICIAL_API_ENDPOINT_RULES,
     build_request,
     classify_api_endpoint,
+    discover_api_endpoint,
     detect_protocol,
+    has_endpoint_discovery,
+    model_catalog_cache_key,
     normalize_api_base_url,
     normalize_response,
 )
@@ -25,6 +29,17 @@ MESSAGES = [
 ]
 
 
+class FakeResponse:
+    def __init__(self, status_code, payload=None):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+
 def test_detect_protocols():
     assert detect_protocol({"api_provider": "anthropic"}) == "anthropic"
     assert detect_protocol({"base_url": "https://x.openai.azure.com"}) == "azure"
@@ -39,6 +54,112 @@ def test_official_endpoint_rules_cover_every_supported_provider_with_evidence():
 
     assert set(OFFICIAL_API_ENDPOINT_RULES) == expected
     assert all(rule["docs_url"].startswith("https://") for rule in OFFICIAL_API_ENDPOINT_RULES.values())
+
+
+def test_endpoint_discovery_registry_covers_supported_non_custom_providers():
+    assert set(API_ENDPOINT_DISCOVERY_RULES) == set(OFFICIAL_API_ENDPOINT_RULES)
+    assert has_endpoint_discovery("kimi") is True
+    assert has_endpoint_discovery("custom") is False
+
+
+def test_kimi_code_key_prefix_only_prioritizes_then_models_confirms():
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return FakeResponse(200, {"data": [{"id": "k3"}]})
+
+    result = discover_api_endpoint("kimi", "sk-kimi-secret", request_get=fake_get)
+
+    assert result.status == "confirmed"
+    assert result.channel == "kimi_code"
+    assert result.base_url == "https://api.kimi.com/coding/v1"
+    assert result.models == ("k3",)
+    assert calls[0][0] == "https://api.kimi.com/coding/v1/models"
+    assert calls[0][1]["headers"]["Authorization"] == "Bearer sk-kimi-secret"
+
+
+def test_kimi_discovery_falls_through_auth_mismatch_to_matching_channel():
+    calls = []
+
+    def fake_get(url, **_kwargs):
+        calls.append(url)
+        if "api.moonshot.cn" in url:
+            return FakeResponse(401, {"error": {"message": "invalid"}})
+        return FakeResponse(200, {"data": [{"id": "kimi-k2.6"}]})
+
+    result = discover_api_endpoint("kimi", "sk-platform", request_get=fake_get)
+
+    assert result.status == "confirmed"
+    assert result.channel == "kimi_global"
+    assert calls[:2] == [
+        "https://api.moonshot.cn/v1/models",
+        "https://api.moonshot.ai/v1/models",
+    ]
+
+
+def test_preferred_registered_endpoint_is_probed_first_for_every_provider():
+    calls = []
+
+    def fake_get(url, **_kwargs):
+        calls.append(url)
+        return FakeResponse(200, {"data": ["model-a"]})
+
+    result = discover_api_endpoint(
+        "minimax",
+        "secret",
+        preferred_base_url="https://api.minimax.io/v1/",
+        request_get=fake_get,
+    )
+
+    assert result.status == "confirmed"
+    assert result.channel == "minimax_global"
+    assert calls == ["https://api.minimax.io/v1/models"]
+
+
+def test_anthropic_discovery_uses_provider_specific_auth_headers():
+    captured = {}
+
+    def fake_get(_url, **kwargs):
+        captured.update(kwargs["headers"])
+        return FakeResponse(200, {"data": [{"id": "claude-test"}]})
+
+    result = discover_api_endpoint("anthropic", "secret", request_get=fake_get)
+
+    assert result.status == "confirmed"
+    assert captured["x-api-key"] == "secret"
+    assert captured["anthropic-version"] == "2023-06-01"
+    assert "Authorization" not in captured
+
+
+def test_discovery_preserves_probable_rate_limited_channel_without_fallback():
+    calls = []
+
+    def fake_get(url, **_kwargs):
+        calls.append(url)
+        return FakeResponse(429, {"error": {"message": "limited"}})
+
+    result = discover_api_endpoint("kimi", "sk-kimi-secret", request_get=fake_get)
+
+    assert result.status == "probable"
+    assert result.channel == "kimi_code"
+    assert result.http_status == 429
+    assert len(calls) == 1
+
+
+def test_unknown_provider_is_not_auto_probed():
+    result = discover_api_endpoint("custom", "secret")
+
+    assert result.status == "unsupported"
+
+
+def test_model_catalog_cache_is_scoped_by_provider_and_normalized_endpoint():
+    code_key = model_catalog_cache_key("kimi", "https://api.kimi.com/coding/")
+    platform_key = model_catalog_cache_key("kimi", "https://api.moonshot.ai/v1")
+
+    assert code_key == "kimi|https://api.kimi.com/coding/v1"
+    assert platform_key == "kimi|https://api.moonshot.ai/v1"
+    assert code_key != platform_key
 
 
 def test_official_endpoint_classification_uses_provider_and_documented_host():

--- a/tests/unit/test_education_certificate.py
+++ b/tests/unit/test_education_certificate.py
@@ -13,10 +13,12 @@ from education_certificate import (
     extract_pdf_text,
     fill_chsi_query_page,
     is_pdf_path,
+    likely_supports_vision,
     normalize_recognition,
     prepare_image_data_url,
     prepare_orientation_sheet_data_url,
     recognize_certificate_pdf,
+    recognize_certificate_image,
     resolve_vision_api_config,
     validate_chsi_fields,
     validate_document_path,
@@ -76,6 +78,47 @@ def test_non_xiaomi_model_is_not_rewritten():
     }
 
     assert resolve_vision_api_config(original) == original
+
+
+def test_k3_is_recognized_as_vision_capable():
+    assert likely_supports_vision({
+        "api_provider": "kimi",
+        "base_url": "https://api.kimi.com/coding/v1",
+        "model": "k3",
+    }) is True
+
+
+def test_kimi_code_image_recognition_uses_larger_output_budget():
+    from unittest.mock import patch
+
+    captured = {}
+
+    def fake_invoke(config, api_key, messages, *, timeout=60, max_tokens=500):
+        captured["max_tokens"] = max_tokens
+        return {
+            "name": "张三",
+            "certificate_number": "123456789012345678",
+            "school": "某大学",
+            "major": "计算机",
+            "confidence": 90,
+            "warnings": [],
+        }
+
+    with patch("education_certificate.prepare_image_data_url", return_value="data:image/jpeg;base64,YQ=="), \
+            patch("education_certificate.prepare_orientation_sheet_data_url", return_value="data:image/jpeg;base64,Yg=="), \
+            patch("education_certificate._invoke_model", side_effect=fake_invoke):
+        result = recognize_certificate_image(
+            "fake.jpg",
+            {
+                "api_provider": "kimi",
+                "base_url": "https://api.kimi.com/coding/v1",
+                "model": "k3",
+            },
+            "key",
+        )
+
+    assert captured["max_tokens"] == 1024
+    assert result.name == "张三"
 
 
 def test_normalize_recognition_cleans_fields_and_warns_non_18_digit_number():

--- a/tests/unit/test_education_certificate.py
+++ b/tests/unit/test_education_certificate.py
@@ -121,6 +121,82 @@ def test_kimi_code_image_recognition_uses_larger_output_budget():
     assert result.name == "张三"
 
 
+def test_kimi_code_captcha_recognition_uses_larger_output_budget():
+    from unittest.mock import patch
+    from education_certificate import recognize_captcha
+
+    captured = {}
+
+    def fake_invoke(config, api_key, messages, *, timeout=60, max_tokens=500):
+        captured["max_tokens"] = max_tokens
+        return {"type": "letter", "answer": "aB3x", "confidence": 90}
+
+    with patch("education_certificate._invoke_model", side_effect=fake_invoke):
+        result = recognize_captcha(
+            "data:image/jpeg;base64,YQ==",
+            {
+                "api_provider": "kimi",
+                "base_url": "https://api.kimi.com/coding/v1",
+                "model": "k3",
+            },
+            "key",
+        )
+
+    assert captured["max_tokens"] == 1024
+    assert result == ("letter", "aB3x", 90)
+
+
+def test_captcha_image_preprocessing_upscales_and_uses_lossless_png():
+    from education_certificate import _image_bytes_to_data_url
+
+    source = io.BytesIO()
+    Image.new("RGB", (100, 40), "white").save(source, format="PNG")
+
+    data_url = _image_bytes_to_data_url(source.getvalue())
+    payload = base64.b64decode(data_url.split(",", 1)[1])
+    with Image.open(io.BytesIO(payload)) as processed:
+        assert data_url.startswith("data:image/png;base64,")
+        assert processed.width >= 400
+        assert processed.height >= 160
+
+
+def test_invoke_model_reports_reasoning_only_length_exhaustion():
+    from unittest.mock import patch
+    from education_certificate import _invoke_model
+
+    class FakeResponse:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {
+                "choices": [{
+                    "finish_reason": "length",
+                    "message": {
+                        "content": "",
+                        "reasoning_content": "still reasoning without final json",
+                    },
+                }],
+            }
+
+    with patch("education_certificate.requests.post", return_value=FakeResponse()):
+        try:
+            _invoke_model(
+                {
+                    "api_provider": "kimi",
+                    "base_url": "https://api.kimi.com/coding/v1",
+                    "model": "k3",
+                },
+                "key",
+                [{"role": "user", "content": "test"}],
+                max_tokens=500,
+            )
+        except RuntimeError as exc:
+            assert "输出长度达到上限" in str(exc)
+        else:
+            raise AssertionError("reasoning-only length response should fail clearly")
+
+
 def test_normalize_recognition_cleans_fields_and_warns_non_18_digit_number():
     result = normalize_recognition({
         "name": " 张 三 ",

--- a/tests/unit/test_gui_job_config.py
+++ b/tests/unit/test_gui_job_config.py
@@ -1264,6 +1264,19 @@ def test_save_api_config_sets_default_when_current_model_is_not_saved():
     assert 'default_summary = "本次保存的模型已设为默认 AI 模型" if should_set_default else "默认 AI 模型保持不变"' in save_block
 
 
+def test_model_discovery_keeps_custom_base_url_explicit_and_scopes_catalog_cache():
+    source = Path("gui_main.py").read_text(encoding="utf-8")
+    fetch_block = source[source.index("def fetch_model_list"):]
+    fetch_block = fetch_block[:fetch_block.index("\n    def _show_api_key_while_pressed")]
+
+    assert 'self.api_base_url_var = tk.StringVar()' in source
+    assert 'text=" 自动识别并获取模型"' in source
+    assert 'if not base_url and not has_endpoint_discovery(provider):' in fetch_block
+    assert '自定义/中转地址只验证用户明确输入的 URL' in fetch_block
+    assert 'resolution = discover_api_endpoint(' in fetch_block
+    assert 'catalog_key = model_catalog_cache_key(provider, base_url)' in fetch_block
+
+
 def test_use_selected_model_matches_provider_and_base_url_not_model_name_only():
     source = Path("gui_main.py").read_text(encoding="utf-8")
     use_block = source[source.index("def use_selected_model"):]

--- a/tests/unit/test_gui_job_config.py
+++ b/tests/unit/test_gui_job_config.py
@@ -1277,6 +1277,45 @@ def test_model_discovery_keeps_custom_base_url_explicit_and_scopes_catalog_cache
     assert 'catalog_key = model_catalog_cache_key(provider, base_url)' in fetch_block
 
 
+def test_education_captcha_low_confidence_is_not_auto_submitted():
+    source = Path("gui_main.py").read_text(encoding="utf-8")
+    solve_block = source[source.index("def _attempt_captcha_solve"):]
+    solve_block = solve_block[:solve_block.index("\n    def _solve_captcha")]
+
+    assert "CAPTCHA_AUTO_SUBMIT_MIN_CONFIDENCE" in solve_block
+    assert "confidence < CAPTCHA_AUTO_SUBMIT_MIN_CONFIDENCE" in solve_block
+    assert 'return False, "待人工验证"' in solve_block
+
+
+def test_education_captcha_retries_three_times_before_manual_fallback():
+    gui = BossFilterGUI.__new__(BossFilterGUI)
+    gui._education_browser_lock = threading.Lock()
+    gui._attempt_captcha_solve = Mock(side_effect=[
+        (False, "待人工验证"),
+        (False, "识别失败"),
+        (False, "待人工验证"),
+    ])
+    progress = []
+
+    with patch("education_certificate.navigate_to_chsi") as navigate, \
+            patch("education_certificate.fill_chsi_query_page") as fill, \
+            patch("gui_main.time.sleep"):
+        result = gui._fill_and_solve_captcha(
+            object(),
+            "张三",
+            "123456789012345678",
+            on_progress=lambda status, detail: progress.append((status, detail)),
+            max_attempts=3,
+        )
+
+    assert result == (False, "待人工验证")
+    assert gui._attempt_captcha_solve.call_count == 3
+    assert navigate.call_count == 3
+    assert fill.call_count == 3
+    assert any("2/3" in status for status, _detail in progress)
+    assert any("3/3" in status for status, _detail in progress)
+
+
 def test_use_selected_model_matches_provider_and_base_url_not_model_name_only():
     source = Path("gui_main.py").read_text(encoding="utf-8")
     use_block = source[source.index("def use_selected_model"):]

--- a/tests/unit/test_gui_job_config.py
+++ b/tests/unit/test_gui_job_config.py
@@ -1000,6 +1000,11 @@ def test_assigned_model_test_result_updates_matching_traffic_light_only():
         "api_provider": "qwen",
         "base_url": "https://example.test/v1",
         "model": "qwen-plus",
+        "education_model_ref": {
+            "api_provider": "kimi",
+            "base_url": "https://example.test/kimi/v1",
+            "model": "k3",
+        },
     }
     gui._assigned_model_test_buttons = {"default": default_button}
     gui._assigned_model_test_icons = {
@@ -1022,6 +1027,85 @@ def test_assigned_model_test_result_updates_matching_traffic_light_only():
 
     assert gui._assigned_model_test_states["default"] == "success"
     assert default_button.configs[-1] == {"image": "green-light"}
+
+
+def test_assigned_model_test_result_syncs_both_roles_when_explicit_model_is_same():
+    gui = BossFilterGUI.__new__(BossFilterGUI)
+    model_ref = {
+        "api_provider": "kimi",
+        "base_url": "https://api.kimi.com/coding/v1",
+        "model": "k3",
+    }
+    gui.api_config = {
+        **model_ref,
+        "education_model_ref": dict(model_ref),
+    }
+    gui.colors = {
+        "text_secondary": "gray", "warning": "yellow",
+        "success": "green", "danger": "red",
+    }
+    gui._assigned_model_test_buttons = {
+        "default": _FakeWidget(), "education": _FakeWidget(),
+    }
+    gui._assigned_model_test_status_labels = {
+        "default": _FakeWidget(), "education": _FakeWidget(),
+    }
+    gui._assigned_model_test_icons = {
+        "pending": "yellow-light", "success": "green-light", "error": "red-light",
+    }
+    gui._assigned_model_test_states = {"default": "testing", "education": "testing"}
+    gui._assigned_model_test_tokens = {"default": 2, "education": 2}
+
+    gui._apply_assigned_model_test_result({
+        "assigned_role": "default",
+        "assigned_test_token": 2,
+        "assigned_model_ref": model_ref,
+    }, {"status": "success"})
+
+    assert gui._assigned_model_test_states == {
+        "default": "success", "education": "success",
+    }
+    assert gui._assigned_model_test_status_labels["default"].configs[-1] == {
+        "text": "已通过", "foreground": "green",
+    }
+    assert gui._assigned_model_test_status_labels["education"].configs[-1] == {
+        "text": "已通过", "foreground": "green",
+    }
+
+
+def test_education_test_result_syncs_failure_back_to_default_when_following():
+    gui = BossFilterGUI.__new__(BossFilterGUI)
+    model_ref = {
+        "api_provider": "qwen",
+        "base_url": "https://example.test/v1",
+        "model": "qwen-plus",
+    }
+    gui.api_config = dict(model_ref)
+    gui.colors = {
+        "text_secondary": "gray", "warning": "yellow",
+        "success": "green", "danger": "red",
+    }
+    gui._assigned_model_test_buttons = {
+        "default": _FakeWidget(), "education": _FakeWidget(),
+    }
+    gui._assigned_model_test_status_labels = {
+        "default": _FakeWidget(), "education": _FakeWidget(),
+    }
+    gui._assigned_model_test_icons = {
+        "pending": "yellow-light", "success": "green-light", "error": "red-light",
+    }
+    gui._assigned_model_test_states = {"default": "testing", "education": "testing"}
+    gui._assigned_model_test_tokens = {"default": 7, "education": 7}
+
+    gui._apply_assigned_model_test_result({
+        "assigned_role": "education",
+        "assigned_test_token": 7,
+        "assigned_model_ref": model_ref,
+    }, {"status": "error"})
+
+    assert gui._assigned_model_test_states == {
+        "default": "error", "education": "error",
+    }
 
 
 def test_assigned_model_test_feedback_identifies_role_and_keeps_rows_independent():

--- a/tests/unit/test_ui_messagebox.py
+++ b/tests/unit/test_ui_messagebox.py
@@ -29,6 +29,23 @@ def test_centered_messagebox_accepts_application_scaled_fonts():
     assert box._button_font == ("App Font", 15)
 
 
+def test_gui_uses_smaller_dedicated_modal_fonts():
+    source = Path("gui_main.py").read_text(encoding="utf-8")
+    setup = source[source.index("messagebox.set_ui_fonts("):]
+    setup = setup[:setup.index("# 设置 Combobox")]
+
+    assert "self.font_log[1] + 1" in setup
+    assert setup.count("self.font_log[1]") == 3
+    assert "message=self.font_label" not in setup
+
+
+def test_api_probe_failure_copy_does_not_claim_connectivity_succeeded():
+    source = Path("gui_main.py").read_text(encoding="utf-8")
+
+    assert "模型连接或兼容性验证未通过" in source
+    assert "API 可访问，但模型不能用于 AI 评估" not in source
+
+
 def test_centered_messagebox_can_reduce_dialog_fonts_by_one_level():
     box = CenteredMessageBox()
 
@@ -100,7 +117,7 @@ def test_all_gui_messagebox_calls_use_centered_proxy():
     assert "from tkinter import filedialog, font, messagebox, ttk" not in gui_source
     assert "from tkinter import ttk, messagebox" not in dialogs_source
     assert "from tkinter import messagebox" not in updater_source
-    assert "headline=(FONT_FAMILY, self.font_label[1], 'bold')" in gui_source
+    assert "headline=(FONT_FAMILY, max(10, self.font_log[1] + 1), 'bold')" in gui_source
     assert "headline=(FONT_FAMILY_SEMIBOLD, self.font_label[1])" not in gui_source
     assert "headline=self.font_section" not in gui_source
 

--- a/tests/unit/test_ui_messagebox.py
+++ b/tests/unit/test_ui_messagebox.py
@@ -34,8 +34,9 @@ def test_gui_uses_smaller_dedicated_modal_fonts():
     setup = source[source.index("messagebox.set_ui_fonts("):]
     setup = setup[:setup.index("# 设置 Combobox")]
 
-    assert "self.font_log[1] + 1" in setup
-    assert setup.count("self.font_log[1]") == 3
+    assert "modal_font_size = max(9, self.font_log[1] - 1)" in source
+    assert "headline=(FONT_FAMILY, max(10, self.font_log[1]), 'bold')" in setup
+    assert setup.count("modal_font_size") == 2
     assert "message=self.font_label" not in setup
 
 
@@ -101,9 +102,28 @@ def test_centered_messagebox_centers_buttons_vertically_in_footer():
     footer_block = source[source.index('footer = tk.Frame(window, bg="#F7F8FA")'):]
     footer_block = footer_block[:footer_block.index('window.protocol("WM_DELETE_WINDOW"')]
 
-    assert 'footer.pack(fill="x", padx=0, pady=0)' in footer_block
+    assert 'footer.grid(row=2, column=0, sticky="ew")' in footer_block
     assert "ipady=14" not in footer_block
     assert footer_block.count("pady=(14, 14)") == 2
+
+
+def test_medium_multiline_message_uses_scrollable_content():
+    message = (
+        "当前学历核验模型可能不支持图片输入。\n\n"
+        "图片识别需要多模态视觉模型，例如：\n"
+        "国外：GPT-4o / GPT-4.1、Claude Sonnet 4、Gemini 2.5 Pro\n"
+        "国内：qwen3.7-plus、mimo-v2.5、GLM-5V、Kimi K2.5、MiniMax-M2.7\n\n"
+        "PDF 文件使用文本提取，不受此限制。\n\n"
+        "可在系统设置的使用中的模型中选择学历核验模型。\n\n"
+        "是否仍要尝试识别？"
+    )
+
+    assert CenteredMessageBox._message_needs_scroll(message) is True
+
+
+def test_dialog_height_is_screen_aware_and_bounded():
+    assert CenteredMessageBox._max_dialog_height(600) == 492
+    assert CenteredMessageBox._max_dialog_height(1080) == 680
 
 
 def test_all_gui_messagebox_calls_use_centered_proxy():
@@ -117,7 +137,7 @@ def test_all_gui_messagebox_calls_use_centered_proxy():
     assert "from tkinter import filedialog, font, messagebox, ttk" not in gui_source
     assert "from tkinter import ttk, messagebox" not in dialogs_source
     assert "from tkinter import messagebox" not in updater_source
-    assert "headline=(FONT_FAMILY, max(10, self.font_log[1] + 1), 'bold')" in gui_source
+    assert "headline=(FONT_FAMILY, max(10, self.font_log[1]), 'bold')" in gui_source
     assert "headline=(FONT_FAMILY_SEMIBOLD, self.font_label[1])" not in gui_source
     assert "headline=self.font_section" not in gui_source
 

--- a/ui_messagebox.py
+++ b/ui_messagebox.py
@@ -1,5 +1,6 @@
 """Parent-centered modal message boxes with tkinter-compatible results."""
 
+import math
 import tkinter as tk
 from tkinter import messagebox as _native_messagebox, ttk
 
@@ -43,6 +44,22 @@ class CenteredMessageBox:
         except (TypeError, ValueError):
             return font_spec
         return tuple(adjusted)
+
+    @staticmethod
+    def _estimated_visual_lines(message, chars_per_line=34):
+        """Estimate wrapped lines so medium multi-line copy becomes scrollable."""
+        lines = str(message or "").splitlines() or [""]
+        return sum(max(1, math.ceil(len(line) / chars_per_line)) for line in lines)
+
+    @classmethod
+    def _message_needs_scroll(cls, message):
+        message = str(message or "")
+        return len(message) > 360 or cls._estimated_visual_lines(message) > 8
+
+    @staticmethod
+    def _max_dialog_height(screen_height):
+        """Keep the modal inside the screen while allowing useful text height."""
+        return min(680, max(320, round(screen_height * 0.82)))
 
     @staticmethod
     def _resolve_parent(parent):
@@ -109,10 +126,14 @@ class CenteredMessageBox:
         window.withdraw()
         window.configure(bg="#FFFFFF")
 
+        window.grid_columnconfigure(0, weight=1)
+        window.grid_rowconfigure(0, weight=1)
+
         body = tk.Frame(window, bg="#FFFFFF")
-        body.pack(
-            fill="both",
-            expand=True,
+        body.grid(
+            row=0,
+            column=0,
+            sticky="nsew",
             padx=26,
             pady=(24, max(0, int(content_bottom_padding))),
         )
@@ -141,14 +162,14 @@ class CenteredMessageBox:
                 anchor="w",
                 wraplength=content_wraplength,
             ).pack(fill="x", anchor="w", pady=(0, 16))
-        is_long = len(message) > 600 or message.count("\n") > 11
+        is_long = self._message_needs_scroll(message)
         if is_long:
             text_frame = tk.Frame(content, bg="#FFFFFF")
             text_frame.pack(fill="both", expand=True)
             text_widget = tk.Text(
                 text_frame,
                 width=64,
-                height=14,
+                height=12,
                 wrap="word",
                 font=message_font,
                 bg="#FFFFFF",
@@ -175,9 +196,11 @@ class CenteredMessageBox:
                 wraplength=content_wraplength,
             ).pack(fill="both", expand=True, anchor="w")
 
-        tk.Frame(window, bg="#E5E7EB", height=1).pack(fill="x")
+        tk.Frame(window, bg="#E5E7EB", height=1).grid(
+            row=1, column=0, sticky="ew"
+        )
         footer = tk.Frame(window, bg="#F7F8FA")
-        footer.pack(fill="x", padx=0, pady=0)
+        footer.grid(row=2, column=0, sticky="ew")
 
         result = {"value": close_value}
         previous_grab = parent.grab_current()
@@ -228,7 +251,8 @@ class CenteredMessageBox:
         window.bind("<Return>", lambda _event: finish(buttons[0][1]))
         window.update_idletasks()
         width = max(int(min_width), min(700, window.winfo_reqwidth()))
-        height = max(180, min(560, window.winfo_reqheight()))
+        max_height = self._max_dialog_height(window.winfo_screenheight())
+        height = max(180, min(max_height, window.winfo_reqheight()))
         self._place(window, width, height, parent)
         window.deiconify()
         window.lift()


### PR DESCRIPTION
## 变更内容

- 兼容 Kimi Code API Key，并自动识别正确的 `https://api.kimi.com/coding/v1` 接入地址
- 区分通义千问公开模型目录与 Token Plan 接入地址，避免错误覆盖 Base URL
- 更新 Kimi K3 图片理解能力判断，并修复固定 temperature=1 的模型请求
- 统一优化提示弹窗字体、尺寸和按钮区域，修复长内容弹窗按钮不可见
- 增强学历验证码图片预处理和 K3 输出预算，所有失败类型统一最多重试 3 次
- 默认 AI 模型与学历核验模型连接身份相同时，双向同步测试状态

## 验证

- `python tests/run_unit_tests.py`：958 项通过，0 失败
- `python tests/test_import.py`：通过
- Python 编译检查：通过
- `git diff --check`：通过
- 已基于最新 `master` 重整提交，模拟合并无冲突