### PR TITLE
fix: 重试新分支的 PR 创建

### DIFF
--- a/scripts/pr_delivery.py
+++ b/scripts/pr_delivery.py
@@ -369,7 +369,8 @@ def _merge_pr(pr: dict[str, Any]) -> dict[str, Any]:
     return current
 
 
-def _update_local_master(expected_sha: str) -> None:
+def _update_local_master(expected_sha: str) -> bool:
+    """Update local master and report whether it is checked out elsewhere."""
     master_worktree = _worktree_for_branch("master")
     if master_worktree is not None:
         _assert_clean_worktree(master_worktree, "本地 master 工作区")
@@ -381,6 +382,7 @@ def _update_local_master(expected_sha: str) -> None:
         _run(["git", "branch", "-f", "master", "origin/master"])
     if _git_text("rev-parse", "master") != expected_sha:
         _fail("本地 master 未能快进到合并提交")
+    return master_worktree is not None
 
 
 def finalize_delivery(branch: str, merge_sha: str) -> dict[str, str]:
@@ -395,12 +397,15 @@ def finalize_delivery(branch: str, merge_sha: str) -> dict[str, str]:
     if gitee_master != merge_sha:
         _fail("Gitee master 与 GitHub master 不一致，拒绝清理分支")
 
-    _update_local_master(merge_sha)
+    master_checked_out_elsewhere = _update_local_master(merge_sha)
 
     if _remote_branch_exists("origin", branch):
         _run(["git", "push", "origin", "--delete", branch])
     if _current_branch() == branch:
-        _run(["git", "switch", "--detach", "origin/master"])
+        if master_checked_out_elsewhere:
+            _run(["git", "switch", "--detach", "origin/master"])
+        else:
+            _run(["git", "switch", "master"])
     if _local_branch_exists(branch):
         _run(["git", "branch", "-D", branch])
 

--- a/scripts/pr_delivery.py
+++ b/scripts/pr_delivery.py
@@ -257,16 +257,31 @@ def _push_and_create_pr(
         print(f"  [复用] PR #{pr['number']}: {pr['url']}")
         return pr
 
-    create_result = _run(
-        [
-            "gh", "pr", "create",
-            "--base", "master",
-            "--head", branch,
-            "--title", title or _default_pr_title(),
-            "--body", _default_pr_body(),
-        ],
-        capture_output=True,
-    )
+    create_args = [
+        "gh", "pr", "create",
+        "--base", "master",
+        "--head", branch,
+        "--title", title or _default_pr_title(),
+        "--body", _default_pr_body(),
+    ]
+    create_result: subprocess.CompletedProcess[str] | None = None
+    for attempt in range(1, 4):
+        create_result = _run(
+            create_args,
+            check=False,
+            capture_output=True,
+        )
+        if create_result.returncode == 0:
+            break
+        existing = _find_delivery_pr(branch, head_sha)
+        if existing is not None:
+            return existing
+        if attempt < 3:
+            print(f"  [重试] GitHub 暂未接受新分支，稍后重试创建 PR（{attempt + 1}/3）")
+            time.sleep(attempt * 2)
+    if create_result is None or create_result.returncode != 0:
+        detail = str((create_result.stderr or create_result.stdout or "未知错误")).strip()
+        _fail(f"PR 创建失败：{detail}")
     print(f"  [OK] PR 已创建: {create_result.stdout.strip()}")
     pr = _find_delivery_pr(branch, head_sha)
     if pr is None:

--- a/tests/unit/test_pr_delivery.py
+++ b/tests/unit/test_pr_delivery.py
@@ -319,3 +319,44 @@ def test_execute_resumes_merged_pr_at_sync_and_cleanup():
     preflight.assert_not_called()
     finalize.assert_called_once_with(branch, merge_sha)
     assert result["merge_sha"] == merge_sha
+
+
+def test_pr_creation_retries_transient_new_branch_propagation_failure():
+    branch = "codex/test"
+    head_sha = "a" * 40
+    pr = {"number": 10, "state": "OPEN", "headRefOid": head_sha}
+    run_results = [
+        _completed(),
+        subprocess.CompletedProcess([], 1, "", "head sha can't be blank"),
+        _completed("https://github.example/pr/10\n"),
+    ]
+    with (
+        patch.object(pr_delivery, "_run", side_effect=run_results),
+        patch.object(pr_delivery, "_find_delivery_pr", side_effect=[None, None, pr]),
+        patch.object(pr_delivery, "_default_pr_title", return_value="Title"),
+        patch.object(pr_delivery, "_default_pr_body", return_value="Body"),
+        patch.object(pr_delivery.time, "sleep") as sleep,
+    ):
+        result = pr_delivery._push_and_create_pr(branch, head_sha)
+
+    assert result == pr
+    sleep.assert_called_once_with(2)
+
+
+def test_pr_creation_reports_final_github_error_after_three_attempts():
+    branch = "codex/test"
+    failures = [
+        _completed(),
+        subprocess.CompletedProcess([], 1, "", "temporary error 1"),
+        subprocess.CompletedProcess([], 1, "", "temporary error 2"),
+        subprocess.CompletedProcess([], 1, "", "final GitHub error"),
+    ]
+    with (
+        patch.object(pr_delivery, "_run", side_effect=failures),
+        patch.object(pr_delivery, "_find_delivery_pr", return_value=None),
+        patch.object(pr_delivery, "_default_pr_title", return_value="Title"),
+        patch.object(pr_delivery, "_default_pr_body", return_value="Body"),
+        patch.object(pr_delivery.time, "sleep"),
+    ):
+        with _raises(pr_delivery.PRDeliveryError, "final GitHub error"):
+            pr_delivery._push_and_create_pr(branch, "a" * 40)

--- a/tests/unit/test_pr_delivery.py
+++ b/tests/unit/test_pr_delivery.py
@@ -157,7 +157,9 @@ def test_finalize_preserves_branches_when_gitee_is_not_synchronized():
             "_remote_ref",
             side_effect=[merge_sha, "b" * 40],
         ),
-        patch.object(pr_delivery, "_update_local_master") as update_master,
+        patch.object(
+            pr_delivery, "_update_local_master", return_value=True
+        ) as update_master,
         patch.object(pr_delivery, "_remote_branch_exists") as remote_exists,
         patch.object(pr_delivery, "_local_branch_exists") as local_exists,
     ):
@@ -191,6 +193,24 @@ def test_finalize_cleans_branch_only_after_both_masters_match():
     update_master.assert_called_once_with(merge_sha)
     assert call(["git", "push", "origin", "--delete", branch]) in run.call_args_list
     assert call(["git", "switch", "--detach", "origin/master"]) in run.call_args_list
+    assert call(["git", "branch", "-D", branch]) in run.call_args_list
+
+
+def test_finalize_returns_primary_worktree_to_master_before_deleting_branch():
+    merge_sha = "a" * 40
+    branch = "codex/test"
+    with (
+        patch.object(pr_delivery, "_run", return_value=_completed()) as run,
+        patch.object(pr_delivery, "_remote_ref", side_effect=[merge_sha, merge_sha]),
+        patch.object(pr_delivery, "_update_local_master", return_value=False),
+        patch.object(pr_delivery, "_remote_branch_exists", side_effect=[False, False]),
+        patch.object(pr_delivery, "_current_branch", return_value=branch),
+        patch.object(pr_delivery, "_local_branch_exists", side_effect=[True, False]),
+    ):
+        pr_delivery.finalize_delivery(branch, merge_sha)
+
+    assert call(["git", "switch", "master"]) in run.call_args_list
+    assert call(["git", "switch", "--detach", "origin/master"]) not in run.call_args_list
     assert call(["git", "branch", "-D", branch]) in run.call_args_list
 
 


### PR DESCRIPTION
## 变更提交

- fix: 一键交付后返回本地主分支
- fix: 重试新分支的 PR 创建

## 自动验证

- 稳定单元回归
- 导入烟测
- `git diff --check`
- PR Checks（合并前等待通过）
