### PR TITLE
fix: 修复正式发布 tag 与清单同步

### DIFF
--- a/scripts/release_ci.py
+++ b/scripts/release_ci.py
@@ -78,6 +78,31 @@ def _git_text(*args: str) -> str:
     return result.stdout.strip()
 
 
+def _configure_git_identity() -> None:
+    """Configure the repository-local identity used by release automation."""
+    _run(["git", "config", "user.name", "github-actions[bot]"])
+    _run([
+        "git", "config", "user.email",
+        "41898282+github-actions[bot]@users.noreply.github.com",
+    ])
+
+
+def _working_tree_paths() -> set[str]:
+    """Return porcelain paths without stripping their status prefix."""
+    result = _run(
+        ["git", "status", "--porcelain"],
+        capture_output=True,
+    )
+    paths: set[str] = set()
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        if len(line) < 4:
+            _fail(f"无法解析 git status 输出：{line!r}")
+        paths.add(line[3:].split(" -> ", 1)[-1].replace("\\", "/"))
+    return paths
+
+
 def _normalize_version(value: str) -> str:
     version = str(value or "").strip().removeprefix("v")
     build._validate_version_format(version)
@@ -262,6 +287,7 @@ def _ensure_origin_tag(tag: str, release_sha: str, notes_path: Path) -> None:
     if local_sha and local_sha != release_sha:
         _fail(f"本地 {tag} 指向其他提交，禁止覆盖")
     if not local_sha:
+        _configure_git_identity()
         _run(["git", "tag", "-a", tag, release_sha, "-F", str(notes_path)])
         print(f"  [OK] 已创建 annotated tag: {tag}")
 
@@ -483,22 +509,13 @@ def _commit_and_sync_manifest(
         require_complete_assets=True,
     )
     if changed:
-        status_lines = _git_text("status", "--porcelain").splitlines()
-        changed_paths = {
-            line[3:].split(" -> ", 1)[-1].replace("\\", "/")
-            for line in status_lines
-            if line.strip()
-        }
+        changed_paths = _working_tree_paths()
         if changed_paths != {"latest.json"}:
             _fail(
                 "更新自动更新清单时出现非预期文件："
                 + ", ".join(sorted(changed_paths))
             )
-        _run(["git", "config", "user.name", "github-actions[bot]"])
-        _run([
-            "git", "config", "user.email",
-            "41898282+github-actions[bot]@users.noreply.github.com",
-        ])
+        _configure_git_identity()
         _run(["git", "add", "latest.json"])
         _run(["git", "commit", "-m", "chore: 更新自动更新清单"])
         _run(["git", "push", "origin", "master"])

--- a/tests/unit/test_release_ci.py
+++ b/tests/unit/test_release_ci.py
@@ -35,6 +35,51 @@ def test_release_authorization_must_match_version_exactly():
         release_ci.validate_authorization("2.21", "release 2.21")
 
 
+def test_origin_tag_configures_git_identity_before_creating_annotated_tag():
+    calls: list[list[str]] = []
+    with (
+        patch.object(release_ci.build, "_remote_tag_commit", return_value=None),
+        patch.object(release_ci, "_commit_for_ref", return_value=None),
+        patch.object(
+            release_ci,
+            "_run",
+            side_effect=lambda args, **_kwargs: calls.append(args),
+        ),
+    ):
+        release_ci._ensure_origin_tag(
+            "v2.21",
+            "a" * 40,
+            Path("release-notes.md"),
+        )
+
+    tag_index = next(i for i, args in enumerate(calls) if args[:2] == ["git", "tag"])
+    assert calls[tag_index - 2] == [
+        "git", "config", "user.name", "github-actions[bot]",
+    ]
+    assert calls[tag_index - 1] == [
+        "git", "config", "user.email",
+        "41898282+github-actions[bot]@users.noreply.github.com",
+    ]
+    assert calls[tag_index + 1] == ["git", "push", "origin", "refs/tags/v2.21"]
+
+
+def test_working_tree_paths_preserves_first_path_character():
+    result = release_ci.subprocess.CompletedProcess(
+        ["git", "status", "--porcelain"],
+        0,
+        stdout=" M latest.json\n",
+        stderr="",
+    )
+    with patch.object(release_ci, "_run", return_value=result) as run:
+        paths = release_ci._working_tree_paths()
+
+    assert paths == {"latest.json"}
+    run.assert_called_once_with(
+        ["git", "status", "--porcelain"],
+        capture_output=True,
+    )
+
+
 def test_resume_rejects_new_business_changes_after_the_release_commit():
     with (
         patch.object(release_ci, "_is_ancestor", return_value=True),


### PR DESCRIPTION
## 变更提交

- fix: 修复正式发布 tag 与清单同步

## 自动验证

- 稳定单元回归
- 导入烟测
- `git diff --check`
- PR Checks（合并前等待通过）
