### PR TITLE
feat(release): 增加单多分支一键发布流程

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ release_notes_cache.json
 .build_progress.json
 .build_state.json
 .release_state.json*
+.release_flow_state.json*
 tests/manual/recon_output/
 tests/manual/build_greet_recovery_contract.py
 tests/manual/capture_manual_greet_network.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,8 @@ boss-resume-filter/
 │   ├── release_ci.py   # GitHub 暂存、本机镜像与正式发布规则
 │   ├── release_content_review.py # 发布内容审核与内部凭证绑定
 │   ├── pr_delivery.py # 普通 PR 一次授权交付（门禁、PR、合并、双远端同步、分支清理）
-│   ├── release_delivery.py / release_prepare.py / release_dispatch.py # 版本准备、PR 交付与正式发布驱动
+│   ├── release_flow.py # 单/多分支一键发布、内容确认与断点续跑统一入口
+│   ├── release_delivery.py / release_prepare.py / release_dispatch.py # 分阶段恢复入口
 │   └── watch_progress.py # 发布进度监控脚本（轮询 .build_progress.json）
 ├── pyinstaller-hooks/    # PyInstaller 自定义 hook（控制模块收集范围，减小产物体积）
 ├── GUI 使用说明.md       # 图形界面操作说明
@@ -82,8 +83,10 @@ boss-resume-filter/
 - 低风险文档、测试和局部文案可在当前工作区修改；普通代码任务使用 `codex/<task>` 短期分支，并行、脏工作区、长周期或高风险任务才创建独立 worktree
 - PR 不作统一要求；核心筛选、自动打招呼、存储、更新器、发布脚本、CI/CD 或大范围修改应使用 PR；面向 `master` 的 PR 由 `PR Checks` 验证，PR 合并始终是独立授权，合并不会触发发布
 - 普通分支推送、PR 合并、删除分支/worktree/临时文件默认须分别获得用户授权。用户准确授权“`一键交付分支 <branch>`”后，该一次授权仅覆盖指定分支的本地门禁、普通 push、创建/复用 PR、等待 `PR Checks`、Squash 合并、同步 GitHub/Gitee `master`、删除本地和远端分支、快进本地 `master`；不覆盖 rebase、force push、worktree 删除、冲突处理或正式发布。任一门禁/CI/一致性检查失败必须停止且不得清理分支
-- 用户准确授权“`一键准备版本 vX.Y`”后，仅允许从干净且双远端一致的 `master` 创建本地 `codex/release-vX.Y`、同步版本材料、运行严格门禁并提交；该分支仍用“`一键交付分支 codex/release-vX.Y`”单独交付。准确授权“`一键准备并交付版本 vX.Y`”后，允许先根据上一公开 tag 到 `master` 的实际变更生成项目外临时发布说明，再顺序组合上述两段权限；任一阶段失败立即停止，已合并时允许幂等收口；两种授权都不覆盖 tag、安装包、GitHub/Gitee Release、rebase、force push、冲突处理或正式发布
-- 用户说“正式发布 vX.Y”时必须先运行只读预览，完整展示最终标题、正文和内容审核结果；只有用户随后准确授权“`确认正式发布 vX.Y`”，才覆盖本机驱动器与 Actions 暂存阶段的严格门禁、tag/清单推送、GitHub/Gitee Release 和线上验收。内容摘要由脚本在后台传递，用户无需输入；版本、发布提交、标题或正文变化后旧确认自动失效
+- 用户准确授权“`一键发布版本 vX.Y`”后，统一入口允许提交当前 `codex/*` 开发分支、同步版本材料、运行严格门禁、普通 push、创建/复用发布候选 PR 并等待 `PR Checks`；随后必须完整展示最终标题、正文、候选提交和内容审核结果并停在内容确认阶段，不得合并、创建 tag、构建安装包或公开 Release。用户可在该阶段反复调整版本内容；每次修改都必须在同一候选 PR 重跑门禁和 CI，并使旧确认自动失效
+- 用户准确授权“`一键发布版本 vX.Y，包含 <branch-a>、<branch-b>...`”时，统一入口可从双远端一致的 `master` 创建 `codex/release-vX.Y` 聚合分支，按声明顺序合入显式列出的干净分支并验证每个分支记录的 GUI 实测提交；不得自动纳入未列出的分支。各分支测试与最终聚合测试都必须通过，冲突、来源不明、实测提交变化或组合回归失败立即停止，不自动解决冲突
+- 只有用户在候选 PR、CI 和最终内容展示完成后准确授权“`确认发布 vX.Y`”，才允许核验内容与候选 tree 凭证、Squash 合并、同步 GitHub/Gitee `master`、触发双平台构建、创建不可变 tag、公开 GitHub/Gitee Release、同步 `latest.json`、完成线上验收并在全部成功后清理已授权分支。候选 tree、版本、标题、正文、PR head、目标分支或测试凭证变化后旧确认自动失效；确认不覆盖 rebase、force push、冲突处理、移动公开 tag 或删除 worktree
+- `release_flow.py` 是正常发布的唯一用户入口；`release_prepare.py`、`release_delivery.py`、`pr_delivery.py` 和 `release_dispatch.py` 仅作为确定性底层与故障恢复入口。任一阶段失败必须保留可恢复状态；GitHub 已公开后不得回滚，只能幂等续跑 Gitee、清单同步和公开验收
 - 发布准备 PR 合并前执行 `/neat-freak`、文案润色和风险相关实测；授权后由工作流重跑严格门禁并核验公开下载、自动更新和双远端状态
 - 已公开 tag 不得移动或覆盖，修复必须发布更高补丁版本；同一提交允许断点续跑
 - `candidates_all.json`、本地 API 配置、Chrome profile 和登录状态不属于任务临时文件，禁止收尾时自动清理
@@ -113,7 +116,7 @@ boss-resume-filter/
 #### 发布命令与门禁
 
 - `python build.py --check [--strict-changelog]`：仅发布前检查；严格模式将 CHANGELOG 启发式覆盖、README 逐条镜像和 latest.json 同步提示升级为硬失败
-- `python scripts/release_delivery.py --version X.Y` 预览版本准备与 PR 交付，增加 `--notes-file <file> --execute --authorization="一键准备并交付版本 vX.Y"` 后执行完整交付；`release_prepare.py` 与 `pr_delivery.py` 保留为分阶段恢复入口；`release_dispatch.py --version X.Y` 是必须的最终内容预览，用户确认后再由脚本传入 `--execute --authorization="确认正式发布 vX.Y" --approved-content-sha <内部凭证>`
+- `python scripts/release_flow.py --version X.Y --notes-file <file> --execute --authorization="一键发布版本 vX.Y"` 准备单分支发布候选并停在内容确认；多分支增加重复的 `--branch <codex/...>` 并使用包含显式分支列表的授权文本。用户确认后由脚本内部续跑 `--confirm --authorization="确认发布 vX.Y"`，内容凭证不要求用户复制。底层 `release_prepare.py`、`release_delivery.py`、`pr_delivery.py` 与 `release_dispatch.py` 仅保留为分阶段恢复入口
 - `python build.py`：自动打包；`--sync-release-notes` 仅用于公开后恢复同步，要求干净且双远端一致的 `master`、已推送且与 CHANGELOG 一致的 `latest.json`，不再自动修改或提交本地文件
 - `python build.py --verify-release X.Y.Z`：只读核验双远端分支/tag、GitHub/Gitee Release、附件完整性和 latest.json，不打包不推送
 - 发布前必须执行 `/neat-freak` 并润色 CHANGELOG 当前版本段落；`gui_main.py` 的 `__version__` 是唯一版本号来源

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,8 @@ boss-resume-filter/
 │   ├── release_ci.py   # GitHub 暂存、本机镜像与正式发布规则
 │   ├── release_content_review.py # 发布内容审核与内部凭证绑定
 │   ├── pr_delivery.py # 普通 PR 一次授权交付（门禁、PR、合并、双远端同步、分支清理）
-│   ├── release_delivery.py / release_prepare.py / release_dispatch.py # 版本准备、PR 交付与正式发布驱动
+│   ├── release_flow.py # 单/多分支一键发布、内容确认与断点续跑统一入口
+│   ├── release_delivery.py / release_prepare.py / release_dispatch.py # 分阶段恢复入口
 │   └── watch_progress.py # 发布进度监控脚本（轮询 .build_progress.json）
 ├── pyinstaller-hooks/    # PyInstaller 自定义 hook（控制模块收集范围，减小产物体积）
 ├── GUI 使用说明.md       # 图形界面操作说明
@@ -82,8 +83,10 @@ boss-resume-filter/
 - 低风险文档、测试和局部文案可在当前工作区修改；普通代码任务使用 `codex/<task>` 短期分支，并行、脏工作区、长周期或高风险任务才创建独立 worktree
 - PR 不作统一要求；核心筛选、自动打招呼、存储、更新器、发布脚本、CI/CD 或大范围修改应使用 PR；面向 `master` 的 PR 由 `PR Checks` 验证，PR 合并始终是独立授权，合并不会触发发布
 - 普通分支推送、PR 合并、删除分支/worktree/临时文件默认须分别获得用户授权。用户准确授权“`一键交付分支 <branch>`”后，该一次授权仅覆盖指定分支的本地门禁、普通 push、创建/复用 PR、等待 `PR Checks`、Squash 合并、同步 GitHub/Gitee `master`、删除本地和远端分支、快进本地 `master`；不覆盖 rebase、force push、worktree 删除、冲突处理或正式发布。任一门禁/CI/一致性检查失败必须停止且不得清理分支
-- 用户准确授权“`一键准备版本 vX.Y`”后，仅允许从干净且双远端一致的 `master` 创建本地 `codex/release-vX.Y`、同步版本材料、运行严格门禁并提交；该分支仍用“`一键交付分支 codex/release-vX.Y`”单独交付。准确授权“`一键准备并交付版本 vX.Y`”后，允许先根据上一公开 tag 到 `master` 的实际变更生成项目外临时发布说明，再顺序组合上述两段权限；任一阶段失败立即停止，已合并时允许幂等收口；两种授权都不覆盖 tag、安装包、GitHub/Gitee Release、rebase、force push、冲突处理或正式发布
-- 用户说“正式发布 vX.Y”时必须先运行只读预览，完整展示最终标题、正文和内容审核结果；只有用户随后准确授权“`确认正式发布 vX.Y`”，才覆盖本机驱动器与 Actions 暂存阶段的严格门禁、tag/清单推送、GitHub/Gitee Release 和线上验收。内容摘要由脚本在后台传递，用户无需输入；版本、发布提交、标题或正文变化后旧确认自动失效
+- 用户准确授权“`一键发布版本 vX.Y`”后，统一入口允许提交当前 `codex/*` 开发分支、同步版本材料、运行严格门禁、普通 push、创建/复用发布候选 PR 并等待 `PR Checks`；随后必须完整展示最终标题、正文、候选提交和内容审核结果并停在内容确认阶段，不得合并、创建 tag、构建安装包或公开 Release。用户可在该阶段反复调整版本内容；每次修改都必须在同一候选 PR 重跑门禁和 CI，并使旧确认自动失效
+- 用户准确授权“`一键发布版本 vX.Y，包含 <branch-a>、<branch-b>...`”时，统一入口可从双远端一致的 `master` 创建 `codex/release-vX.Y` 聚合分支，按声明顺序合入显式列出的干净分支并验证每个分支记录的 GUI 实测提交；不得自动纳入未列出的分支。各分支测试与最终聚合测试都必须通过，冲突、来源不明、实测提交变化或组合回归失败立即停止，不自动解决冲突
+- 只有用户在候选 PR、CI 和最终内容展示完成后准确授权“`确认发布 vX.Y`”，才允许核验内容与候选 tree 凭证、Squash 合并、同步 GitHub/Gitee `master`、触发双平台构建、创建不可变 tag、公开 GitHub/Gitee Release、同步 `latest.json`、完成线上验收并在全部成功后清理已授权分支。候选 tree、版本、标题、正文、PR head、目标分支或测试凭证变化后旧确认自动失效；确认不覆盖 rebase、force push、冲突处理、移动公开 tag 或删除 worktree
+- `release_flow.py` 是正常发布的唯一用户入口；`release_prepare.py`、`release_delivery.py`、`pr_delivery.py` 和 `release_dispatch.py` 仅作为确定性底层与故障恢复入口。任一阶段失败必须保留可恢复状态；GitHub 已公开后不得回滚，只能幂等续跑 Gitee、清单同步和公开验收
 - 发布准备 PR 合并前执行 `/neat-freak`、文案润色和风险相关实测；授权后由工作流重跑严格门禁并核验公开下载、自动更新和双远端状态
 - 已公开 tag 不得移动或覆盖，修复必须发布更高补丁版本；同一提交允许断点续跑
 - `candidates_all.json`、本地 API 配置、Chrome profile 和登录状态不属于任务临时文件，禁止收尾时自动清理
@@ -113,7 +116,7 @@ boss-resume-filter/
 #### 发布命令与门禁
 
 - `python build.py --check [--strict-changelog]`：仅发布前检查；严格模式将 CHANGELOG 启发式覆盖、README 逐条镜像和 latest.json 同步提示升级为硬失败
-- `python scripts/release_delivery.py --version X.Y` 预览版本准备与 PR 交付，增加 `--notes-file <file> --execute --authorization="一键准备并交付版本 vX.Y"` 后执行完整交付；`release_prepare.py` 与 `pr_delivery.py` 保留为分阶段恢复入口；`release_dispatch.py --version X.Y` 是必须的最终内容预览，用户确认后再由脚本传入 `--execute --authorization="确认正式发布 vX.Y" --approved-content-sha <内部凭证>`
+- `python scripts/release_flow.py --version X.Y --notes-file <file> --execute --authorization="一键发布版本 vX.Y"` 准备单分支发布候选并停在内容确认；多分支增加重复的 `--branch <codex/...>` 并使用包含显式分支列表的授权文本。用户确认后由脚本内部续跑 `--confirm --authorization="确认发布 vX.Y"`，内容凭证不要求用户复制。底层 `release_prepare.py`、`release_delivery.py`、`pr_delivery.py` 与 `release_dispatch.py` 仅保留为分阶段恢复入口
 - `python build.py`：自动打包；`--sync-release-notes` 仅用于公开后恢复同步，要求干净且双远端一致的 `master`、已推送且与 CHANGELOG 一致的 `latest.json`，不再自动修改或提交本地文件
 - `python build.py --verify-release X.Y.Z`：只读核验双远端分支/tag、GitHub/Gitee Release、附件完整性和 latest.json，不打包不推送
 - 发布前必须执行 `/neat-freak` 并润色 CHANGELOG 当前版本段落；`gui_main.py` 的 `__version__` 是唯一版本号来源

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -15,17 +15,20 @@
 
 ### 正式发布（Actions 构建 + 本机镜像）
 
-正式发布的唯一用户入口是本机 `scripts/release_dispatch.py`。PR 合并后必须先运行只读预览，脚本会完整展示标题、正文和内容审核结果。用户确认“确认正式发布 vX.Y”后，内容凭证由脚本在后台传给 Actions；用户无需手工复制摘要。版本、提交、标题或正文任一变化都会使旧确认失效。
+正常发布的唯一用户入口是本机 `scripts/release_flow.py`。它把开发分支提交、版本材料、候选 PR、CI 等待、内容确认、正式发布和线上验收串成一个可恢复状态机；唯一正常停点是最终标题和正文确认。`release_prepare.py`、`release_delivery.py`、`pr_delivery.py` 与 `release_dispatch.py` 仅保留为分阶段恢复入口。
 
 ```bash
-# 默认只读预览，不触发 Actions
-python scripts/release_dispatch.py --version 2.22
-
-# 精确授权后触发、等待并核验公开版本
-python scripts/release_dispatch.py --version 2.22 \
+# 准备单分支候选 PR，等待 CI 后展示最终版本内容并停止
+python scripts/release_flow.py --version 2.24 \
+  --notes-file "<项目目录外的发布说明文件>" \
   --execute \
-  --authorization="确认正式发布 v2.22" \
-  --approved-content-sha="<预览输出的内部凭证>"
+  --authorization="一键发布版本 v2.24"
+
+# 用户确认已展示内容后，自动合并并发布到完整验收成功
+python scripts/release_flow.py --version 2.24 \
+  --confirm \
+  --approved-content-sha="<由编排器从预览结果后台传入>" \
+  --authorization="确认发布 v2.24"
 ```
 
 确定性发布规则仍统一放在 `scripts/release_ci.py`，不是两套实现；`.github/workflows/release.yml` 只运行其中的 GitHub 暂存阶段，本机驱动器运行 Gitee 镜像和最终发布阶段。不要把 Actions 暂存任务成功误判为正式版本已经公开。
@@ -41,13 +44,15 @@ python scripts/release_dispatch.py --version 2.22 \
 7. Gitee Release 附件齐全且 size 与 GitHub 一致后，本机生成 `latest.json` 的双源下载地址和 SHA256，提交并推送到 GitHub/Gitee `master`。
 8. 只读核验双远端分支/tag/Release/附件/清单，并实际请求六个公开下载地址和两份在线清单。
 
-**断点续跑：**流程按“版本 + 发布提交”恢复。GitHub Draft 的三个附件已经完整时，再次执行同一正式发布命令会跳过 Actions，直接从本机 Gitee 镜像阶段继续；本机下载使用 `.part` 文件续传，45 秒没有收到新数据即中断当前请求并保留已下载字节。`.release_state.json` 记录当前阶段和各附件字节数，不保存 Token 或下载 URL。已存在的同提交 tag 不重建，本地缺少 tag 时自动从 GitHub 精确拉取；已一致的 Gitee 附件不重传。同名 tag 指向其他提交、或发布期间 `master` 出现非 `latest.json` 业务变更时立即中止，绝不移动 tag 或强制推送。
+**断点续跑：**`.release_flow_state.json` 记录候选分支、PR、候选提交、tree、内容摘要和当前阶段，`.release_state.json` 记录正式发布阶段和附件下载进度；两者都不保存 Token。候选内容变化后重新执行准备命令会更新同一 PR、重跑 CI 并产生新摘要。GitHub Draft 的三个附件已经完整时，确认命令重跑会跳过 Actions，直接从本机 Gitee 镜像阶段继续；本机下载使用 `.part` 文件续传。已存在的同提交 tag 不重建，同名 tag 指向其他提交时立即中止。
 
 **停滞与重试：**GitHub Release 和 Actions 状态查询遇到瞬态网络失败会按上限重试。Actions 连续 30 分钟没有 job/step 阶段变化时，本机停止等待并保留远端任务，排查后可用同一版本安全续跑。发布暂存 job 只安装 `requirements-release.txt`，双平台构建使用 `requirements-build.txt` 作为独立 pip 缓存键，避免每次重新下载完整发布依赖。
 
 **Dry Run：**将 `dry_run` 设为 `true` 时只执行授权校验和严格门禁，不构建、不创建 tag、不推送、不发布。
 
-**凭据配置：**Actions 只使用 `GITHUB_TOKEN` 创建 tag、Draft Release 和上传附件，不保存也不使用 `GITEE_TOKEN`。正式发布前，本机必须提供具有 Gitee projects 权限的 `GITEE_TOKEN`；缺失或 Gitee API 不可达时会在触发 Actions 前停止。本地 `build.py --release` 仍停用，正式发布统一从 `release_dispatch.py` 进入。
+**多分支聚合：**重复传入 `--branch` 显式声明纳入顺序，并为每个分支传入与手工 GUI 实测一致的 `--tested-branch branch=commit_sha`。每个分支必须有独立且干净的 worktree；脚本先在各自目录运行稳定回归和导入烟测，再从同步的 `master` 创建 `codex/release-vX.Y`，逐个合入并对组合结果重新执行完整门禁。冲突、实测 SHA 变化、分支独立测试或组合测试失败都立即停止。示例授权：`一键发布版本 v2.24，包含 codex/a、codex/b`。
+
+**凭据配置：**Actions 只使用 `GITHUB_TOKEN` 创建 tag、Draft Release 和上传附件，不保存也不使用 `GITEE_TOKEN`。正式发布前，本机必须提供具有 Gitee projects 权限的 `GITEE_TOKEN`；缺失或 Gitee API 不可达时会在触发 Actions 前停止。本地 `build.py --release` 仍停用，正常发布统一从 `release_flow.py` 进入。
 
 Release 页面最终包含：
 
@@ -105,17 +110,14 @@ python build.py --check --strict-changelog
 # 使用自动打包脚本（推荐）
 python build.py
 
-# 版本准备与 PR 交付预览：检查双远端、版本范围、提交和变更文件，不改文件
-python scripts/release_delivery.py --version 2.22
+# 单分支：准备候选 PR、等待 CI、展示最终内容
+python scripts/release_flow.py --version 2.24 --notes-file "<项目目录外的发布说明文件>" --execute --authorization "一键发布版本 v2.24"
 
-# 已复核发布说明后：一次完成版本材料、严格门禁、提交、PR、CI、合并、双远端同步和分支清理
-python scripts/release_delivery.py --version 2.22 --notes-file "<项目目录外的发布说明文件>" --execute --authorization "一键准备并交付版本 v2.22"
+# 多分支：每个分支都必须带匹配其 HEAD 的 GUI 实测凭证
+python scripts/release_flow.py --version 2.24 --notes-file "<项目目录外的发布说明文件>" --branch codex/a --branch codex/b --tested-branch "codex/a=<sha-a>" --tested-branch "codex/b=<sha-b>" --execute --authorization "一键发布版本 v2.24，包含 codex/a、codex/b"
 
-# 发布准备分支交付后：只读预览正式发布
-python scripts/release_dispatch.py --version 2.22
-
-# 用户确认预览内容后正式发布（内容凭证由调用方传入）
-python scripts/release_dispatch.py --version 2.22 --execute --authorization "确认正式发布 v2.22" --approved-content-sha "<sha256>"
+# 内容确认后自动合并、构建、双源发布、清单同步和线上验收
+python scripts/release_flow.py --version 2.24 --confirm --approved-content-sha "<由编排器后台传入>" --authorization "确认发布 v2.24"
 
 # 发布完成后只读核验 GitHub/Gitee、附件和 latest.json
 python build.py --verify-release 2.5
@@ -144,7 +146,7 @@ pyinstaller --onefile --noconsole \
 - `python tests/test_import.py` 通过
 - 工作区干净
 
-正式发布工作流不会提交业务代码或自动改版本号；版本号、更新说明和用户文档必须随发布准备 PR 一起合并。推荐使用 `scripts/release_delivery.py`：默认只读；执行必须提供经过复核的发布说明文件和精确授权“`一键准备并交付版本 vX.Y`”，自动完成本地 `codex/release-vX.Y` 的准备、交付与清理，但不创建 tag、安装包或公开 Release。`release_prepare.py` 与 `pr_delivery.py` 保留为分阶段执行和故障恢复入口。
+`release_flow.py` 要求开发修改已经由 Codex 完成语义审查和提交；确定性脚本不自行猜测哪些脏文件属于本次任务。它在当前单分支或显式多分支聚合结果上同步版本材料、运行严格门禁、推送候选 PR 并等待 CI，然后停在内容确认。内容调整继续使用同一 PR；确认前不得合并，确认后才连续执行正式发布。底层脚本保留用于失败后的分阶段恢复。
 
 Release 标题和说明必须先写在 `CHANGELOG.md` 对应版本段落中。`scripts/release_ci.py` 会自动提取该段落作为 GitHub/Gitee Release 内容；如果缺少对应版本，或未按以下顺序分类，发布会直接中断：
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,8 @@ boss-resume-filter/
 ├── tests/                # 测试脚本目录
 ├── scripts/              # 辅助脚本目录
 │   ├── pr_delivery.py  # 普通 PR 一次授权交付
-│   ├── release_delivery.py # 版本准备与发布准备 PR 一键交付
+│   ├── release_flow.py # 单/多分支一键发布统一入口
+│   ├── release_delivery.py # 版本准备与发布准备 PR 分阶段恢复
 │   ├── release_prepare.py # 本地版本准备、门禁与提交
 │   ├── release_dispatch.py # 正式发布触发、监控与验收
 │   ├── release_ci.py   # GitHub 暂存、本机镜像与正式发布规则

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,34 +12,33 @@ python tests/test_import.py
 ## 活跃脚本
 
 - `release_ci.py`：正式发布的确定性规则实现；Actions 只调用严格门禁和 GitHub Draft 暂存，本机驱动器校验附件后先公开 GitHub 主源，再镜像 Gitee、同步清单并完成线上验收；行为测试在 `tests/unit/test_release_ci.py`。
-- `release_content_review.py`：对最终标题和正文做固定用户视角审核，并绑定版本、发布提交和内容凭证。
-- `release_delivery.py`：一次授权组合版本材料准备与发布准备 PR 交付，不触发正式发布；行为测试在 `tests/unit/test_release_delivery.py`。
+- `release_flow.py`：正常发布唯一入口；支持单分支和显式多分支聚合，把候选 PR、内容确认、Squash tree 校验、正式发布与断点续跑串成一个状态机；行为测试在 `tests/unit/test_release_flow.py`。
+- `release_content_review.py`：对最终标题和正文做固定用户视角审核；确认前绑定候选 tree，合并后绑定正式发布提交。
+- `release_delivery.py`：旧版版本准备与 PR 组合入口，仅保留为分阶段恢复入口；行为测试在 `tests/unit/test_release_delivery.py`。
 - `release_prepare.py`：版本号、CHANGELOG、README 与项目版本注释的本地准备和严格门禁，保留为分阶段执行及故障恢复入口。
-- `release_dispatch.py`：正式发布的唯一用户入口，负责预检、触发或跳过 Actions 暂存、本机公开 GitHub 主源、Gitee 镜像和最终验收。
+- `release_dispatch.py`：正式发布底层入口，负责预检、触发或跳过 Actions 暂存、本机公开 GitHub 主源、Gitee 镜像和最终验收。
 - `pr_delivery.py`：普通开发分支的一次授权交付编排，负责本地门禁、push、PR、CI 等待、Squash 合并、双远端同步和安全分支清理；默认只预览，行为测试在 `tests/unit/test_pr_delivery.py`。
 - `watch_progress.py`：轮询 `.build_progress.json` 并输出本地打包状态，保留作为手工构建辅助工具。
 
 版本准备、一键交付和正式发布入口会优先使用项目 `pack_venv`；即使通过系统 Python 或 Anaconda Python 启动，也会在执行仓库检查前自动切换。
 
-### 版本准备与 PR 一键交付
-
-默认只读检查版本范围和仓库状态：
+### 单分支一键发布
 
 ```powershell
-python scripts/release_delivery.py --version 2.22
-```
-
-发布说明复核完成后，将临时文件放在项目目录外，并准确授权“`一键准备并交付版本 v2.22`”：
-
-```powershell
-python scripts/release_delivery.py `
-  --version 2.22 `
+python scripts/release_flow.py `
+  --version 2.24 `
   --notes-file "<项目目录外的发布说明文件>" `
   --execute `
-  --authorization "一键准备并交付版本 v2.22"
+  --authorization "一键发布版本 v2.24"
 ```
 
-流程自动完成版本材料同步、严格门禁、本地提交、push、PR、CI 等待、Squash 合并、双远端同步和分支清理。任一阶段失败立即停止；不会创建 tag、安装包或公开 Release。完成后必须先运行 `release_dispatch.py --version X.Y` 展示最终内容，再等待用户确认。
+脚本完成版本材料、严格门禁、push、候选 PR 和 CI 后展示最终内容并停止。需要调整时更新项目外说明文件并重跑同一命令；同一 PR 会更新，旧内容凭证失效。确认后执行：
+
+```powershell
+python scripts/release_flow.py --version 2.24 --confirm --approved-content-sha "<由编排器后台传入>" --authorization "确认发布 v2.24"
+```
+
+确认后自动完成 Squash 合并、双远端同步、双平台构建、GitHub/Gitee Release、`latest.json` 和线上验收。多分支使用重复的 `--branch` 与 `--tested-branch branch=commit_sha`；每个分支必须有独立干净的 worktree，脚本会先在各自目录重跑稳定回归和导入烟测，再验证聚合结果。分支顺序同时进入精确授权文本。任一失败保留状态，不自动处理冲突、rebase、force push 或删除 worktree。
 
 ### 普通 PR 一键交付
 

--- a/scripts/pr_delivery.py
+++ b/scripts/pr_delivery.py
@@ -374,7 +374,7 @@ def _pr_view(number: int) -> dict[str, Any]:
             [
             "gh", "pr", "view", str(number),
             "--json",
-            "number,state,isDraft,url,mergeable,mergeStateStatus,statusCheckRollup,mergeCommit",
+            "number,state,isDraft,url,headRefOid,baseRefOid,mergeable,mergeStateStatus,statusCheckRollup,mergeCommit",
             ],
             f"读取 PR #{number} 状态",
         )

--- a/scripts/release_content_review.py
+++ b/scripts/release_content_review.py
@@ -34,8 +34,8 @@ def content_sha256(version: str, release_sha: str, title: str, body: str) -> str
     return hashlib.sha256(payload).hexdigest()
 
 
-def review_release_content(version: str, release_sha: str) -> dict[str, Any]:
-    """Run the fixed user-facing audit and return immutable review evidence."""
+def _review_user_facing_content(version: str) -> tuple[str, str, list[str]]:
+    """Extract the current release text and enforce the fixed user-facing audit."""
     title, body = build._extract_changelog_release(version)
     issues = audit_user_facing_release(BASE_DIR)
     blocking = [
@@ -45,11 +45,37 @@ def review_release_content(version: str, release_sha: str) -> dict[str, Any]:
     if blocking:
         details = "; ".join(f"{issue.title}: {issue.detail}" for issue in blocking)
         raise ReleaseContentReviewError(f"发布内容审核未通过：{details}")
+    warnings = [issue.title for issue in issues if issue.severity == "warning"]
+    return title, body, warnings
+
+
+def review_release_content(version: str, release_sha: str) -> dict[str, Any]:
+    """Run the fixed user-facing audit and return immutable review evidence."""
+    title, body, warnings = _review_user_facing_content(version)
     return {
         "release_title": title,
         "release_body": body,
         "content_sha": content_sha256(version, release_sha, title, body),
-        "review_warnings": [issue.title for issue in issues if issue.severity == "warning"],
+        "review_warnings": warnings,
+    }
+
+
+def review_release_candidate(
+    version: str,
+    candidate_sha: str,
+    candidate_tree_sha: str,
+) -> dict[str, Any]:
+    """Bind human approval to the exact candidate tree before Squash merge."""
+    title, body, warnings = _review_user_facing_content(version)
+    return {
+        "release_title": title,
+        "release_body": body,
+        "candidate_sha": candidate_sha,
+        "candidate_tree_sha": candidate_tree_sha,
+        "content_sha": content_sha256(
+            version, f"tree:{candidate_tree_sha}", title, body,
+        ),
+        "review_warnings": warnings,
     }
 
 

--- a/scripts/release_flow.py
+++ b/scripts/release_flow.py
@@ -1,0 +1,477 @@
+"""Single user-facing, resumable release flow for one or more topic branches.
+
+The start authorization prepares and validates a release-candidate PR, then
+stops after printing the exact user-facing release content. Confirmation
+verifies the immutable candidate evidence, Squash merges the PR, and reuses the
+existing formal-release driver through public verification.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = Path(__file__).resolve().parent
+for import_path in (BASE_DIR, SCRIPTS_DIR):
+    if str(import_path) not in sys.path:
+        sys.path.insert(0, str(import_path))
+
+import pr_delivery  # noqa: E402
+import release_content_review  # noqa: E402
+import release_dispatch  # noqa: E402
+import release_prepare  # noqa: E402
+
+
+STATE_PATH = BASE_DIR / ".release_flow_state.json"
+STATE_SCHEMA = 1
+
+
+class ReleaseFlowError(RuntimeError):
+    """The unified release transaction cannot safely continue."""
+
+
+def _fail(message: str) -> None:
+    raise ReleaseFlowError(message)
+
+
+def _run(
+    args: list[str],
+    *,
+    cwd: Path | None = None,
+    check: bool = True,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd or BASE_DIR,
+        check=check,
+        capture_output=capture_output,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def _git_text(*args: str) -> str:
+    return _run(["git", *args], capture_output=True).stdout.strip()
+
+
+def _tree_sha(ref: str) -> str:
+    return _git_text("rev-parse", f"{ref}^{{tree}}")
+
+
+def _read_state() -> dict[str, Any]:
+    if not STATE_PATH.is_file():
+        _fail("没有可确认的一键发布状态；请先准备发布候选")
+    try:
+        state = json.loads(STATE_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        _fail(f"一键发布状态文件损坏：{exc}")
+    if state.get("schema") != STATE_SCHEMA:
+        _fail("一键发布状态版本不兼容，请人工检查后重新准备")
+    return state
+
+
+def _write_state(state: dict[str, Any]) -> None:
+    payload = {"schema": STATE_SCHEMA, **state}
+    temporary = STATE_PATH.with_suffix(STATE_PATH.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, STATE_PATH)
+
+
+def expected_start_authorization(version: str, branches: list[str]) -> str:
+    version = release_prepare.normalize_version(version)
+    if len(branches) <= 1:
+        return f"一键发布版本 v{version}"
+    return f"一键发布版本 v{version}，包含 " + "、".join(branches)
+
+
+def expected_confirm_authorization(version: str) -> str:
+    return f"确认发布 v{release_prepare.normalize_version(version)}"
+
+
+def _validate_authorization(actual: str, expected: str, label: str) -> None:
+    if actual != expected:
+        _fail(f"{label}授权不匹配：必须准确填写 {expected!r}")
+
+
+def _validate_notes_file(notes_file: Path | None) -> Path:
+    if notes_file is None:
+        _fail("准备发布候选必须提供 --notes-file")
+    path = notes_file if notes_file.is_absolute() else BASE_DIR / notes_file
+    path = path.resolve()
+    if path == BASE_DIR or BASE_DIR in path.parents:
+        _fail("发布说明是临时输入文件，必须放在项目目录之外")
+    if not path.is_file():
+        _fail(f"发布说明文件不存在：{path}")
+    return path
+
+
+def _assert_clean(label: str = "当前工作区") -> None:
+    if _git_text("status", "--porcelain"):
+        _fail(f"{label}存在未提交修改")
+
+
+def _fetch_and_verify_masters() -> str:
+    pr_delivery._run_external(["git", "fetch", "origin"], "拉取 GitHub 更新")
+    pr_delivery._run_external(["git", "fetch", "gitee"], "拉取 Gitee 更新")
+    origin = _git_text("rev-parse", "origin/master")
+    gitee = _git_text("rev-parse", "gitee/master")
+    if origin != gitee:
+        _fail("GitHub/Gitee master 不一致，拒绝准备发布")
+    return origin
+
+
+def _tested_map(values: list[str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for value in values:
+        branch, separator, sha = value.partition("=")
+        if not separator or not branch or not sha:
+            _fail("--tested-branch 必须使用 branch=commit_sha 格式")
+        if not re.fullmatch(r"[0-9a-fA-F]{40}", sha):
+            _fail("--tested-branch 必须记录完整的 40 位 commit SHA")
+        result[pr_delivery.validate_branch_name(branch)] = sha
+    return result
+
+
+def _validate_source_branches(branches: list[str], tested: dict[str, str]) -> None:
+    for branch in branches:
+        pr_delivery.validate_branch_name(branch)
+        if not pr_delivery._local_branch_exists(branch):
+            _fail(f"本地分支不存在：{branch}")
+        worktree = pr_delivery._worktree_for_branch(branch)
+        if worktree is None:
+            _fail(f"分支 {branch} 没有独立 worktree，无法在其自身目录验证")
+        pr_delivery._assert_clean_worktree(worktree, f"分支 {branch} 工作区")
+        head = _git_text("rev-parse", branch)
+        if tested.get(branch) != head:
+            _fail(f"分支 {branch} 缺少与当前提交一致的 GUI 实测凭证：{head}")
+        print(f"\n>>> 分支独立回归：{branch} ({worktree})")
+        _run([sys.executable, "tests/run_unit_tests.py"], cwd=worktree)
+        _run([sys.executable, "tests/test_import.py"], cwd=worktree)
+        pr_delivery._assert_clean_worktree(worktree, f"分支 {branch} 测试后工作区")
+
+
+def _prepare_aggregate_branch(
+    version: str,
+    branches: list[str],
+    tested: dict[str, str],
+    master_sha: str,
+) -> str:
+    _validate_source_branches(branches, tested)
+    branch = release_prepare.release_branch(version)
+    if pr_delivery._local_branch_exists(branch):
+        if _git_text("branch", "--show-current") != branch:
+            _fail(f"聚合分支 {branch} 已存在，请在该分支续跑或人工检查")
+        missing = [
+            source for source in branches
+            if not pr_delivery._is_ancestor(source, branch)
+        ]
+        if missing:
+            _fail("现有聚合分支未完整包含：" + "、".join(missing))
+        return branch
+    if _git_text("branch", "--show-current") != "master":
+        _fail("多分支聚合必须从本地 master 启动")
+    if _git_text("rev-parse", "HEAD") != master_sha:
+        _fail("本地 master 不是最新 origin/master")
+    _run(["git", "switch", "-c", branch, "origin/master"])
+    for source in branches:
+        result = _run(
+            ["git", "merge", "--no-ff", "--no-edit", source],
+            check=False,
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            _fail(f"聚合分支 {source} 时发生冲突；已停止且不会自动解决")
+    return branch
+
+
+def _prepare_single_branch(branches: list[str], master_sha: str) -> str:
+    branch = branches[0] if branches else _git_text("branch", "--show-current")
+    branch = pr_delivery.validate_branch_name(branch)
+    if _git_text("branch", "--show-current") != branch:
+        _fail(f"单分支发布必须在 {branch} 对应目录执行")
+    if not pr_delivery._is_ancestor("origin/master", "HEAD"):
+        _fail("开发分支未基于最新 origin/master，自动流程不会 rebase")
+    if _git_text("rev-parse", "HEAD") == master_sha:
+        _fail("开发分支没有需要发布的提交")
+    return branch
+
+
+def _apply_release_materials(version: str, notes_path: Path) -> None:
+    title, body = release_prepare.parse_release_notes(
+        notes_path.read_text(encoding="utf-8"), version,
+    )
+    release_prepare.apply_release_materials(version, title, body)
+    changed = release_prepare._status_paths()
+    unexpected = changed - release_prepare.RELEASE_FILES
+    if unexpected:
+        _fail("发布材料阶段出现意外修改：" + ", ".join(sorted(unexpected)))
+    if changed:
+        release_prepare._run_strict_gate()
+        _run(["git", "add", *sorted(release_prepare.RELEASE_FILES)])
+        _run(["git", "diff", "--cached", "--check"])
+        _run(["git", "commit", "-m", f"chore: 准备 v{version} 正式发布"])
+    else:
+        release_prepare._run_strict_gate()
+
+
+def _print_candidate(state: dict[str, Any]) -> None:
+    print(f"\n>>> v{state['version']} 最终版本内容（等待人工确认）")
+    print(f"  候选分支: {state['candidate_branch']}")
+    print(f"  候选提交: {state['candidate_sha']}")
+    print(f"  候选 tree: {state['candidate_tree_sha']}")
+    print(f"  PR: {state['pr_url']}")
+    print(f"  标题: {state['release_title']}")
+    print(state["release_body"])
+    print(f"\n  内部内容凭证: {state['content_sha'][:12]}")
+    print(f"  确认口令: {expected_confirm_authorization(state['version'])}")
+
+
+def prepare_candidate(
+    version: str,
+    *,
+    notes_file: Path | None,
+    branches: list[str],
+    tested_branches: list[str],
+    authorization: str,
+    timeout: int,
+    poll_interval: int,
+) -> dict[str, Any]:
+    """Prepare or update one candidate PR and stop before merge."""
+    version = release_prepare.normalize_version(version)
+    normalized = [pr_delivery.validate_branch_name(item) for item in branches]
+    if len(set(normalized)) != len(normalized):
+        _fail("发布分支列表包含重复项")
+    effective = normalized or [_git_text("branch", "--show-current")]
+    _validate_authorization(
+        authorization,
+        expected_start_authorization(version, effective),
+        "一键发布",
+    )
+    notes_path = _validate_notes_file(notes_file)
+    _assert_clean()
+    master_sha = _fetch_and_verify_masters()
+    release_prepare.assert_target_tag_available(version)
+    if len(effective) > 1:
+        candidate_branch = _prepare_aggregate_branch(
+            version, effective, _tested_map(tested_branches), master_sha,
+        )
+    else:
+        candidate_branch = _prepare_single_branch(effective, master_sha)
+
+    _apply_release_materials(version, notes_path)
+    gate = pr_delivery.preflight(candidate_branch, run_tests=False)
+    pr = pr_delivery._push_and_create_pr(
+        candidate_branch,
+        gate["head_sha"],
+        title=f"chore: 准备 v{version} 正式发布",
+    )
+    checked = pr_delivery.wait_for_pr_checks(
+        int(pr["number"]), timeout=timeout, poll_interval=poll_interval,
+    )
+    candidate_sha = gate["head_sha"]
+    candidate_tree = _tree_sha(candidate_sha)
+    review = release_content_review.review_release_candidate(
+        version, candidate_sha, candidate_tree,
+    )
+    state = {
+        "phase": "awaiting_content_approval",
+        "version": version,
+        "source_branches": effective,
+        "tested_branches": _tested_map(tested_branches),
+        "candidate_branch": candidate_branch,
+        "candidate_sha": candidate_sha,
+        "candidate_tree_sha": candidate_tree,
+        "base_sha": master_sha,
+        "pr_number": int(checked["number"]),
+        "pr_url": checked.get("url") or pr.get("url") or "",
+        **review,
+    }
+    _write_state(state)
+    _print_candidate(state)
+    return state
+
+
+def _verify_candidate(
+    state: dict[str, Any],
+    *,
+    timeout: int,
+    poll_interval: int,
+) -> dict[str, Any]:
+    branch = str(state["candidate_branch"])
+    sha = str(state["candidate_sha"])
+    if _git_text("branch", "--show-current") != branch:
+        _fail(f"内容确认必须在候选分支 {branch} 的原 worktree 执行")
+    _assert_clean("内容确认前当前工作区")
+    if _git_text("rev-parse", branch) != sha:
+        _fail("候选分支提交在确认前发生变化；必须重新展示版本内容")
+    if _tree_sha(sha) != state["candidate_tree_sha"]:
+        _fail("候选文件树在确认前发生变化；必须重新展示版本内容")
+    review = release_content_review.review_release_candidate(
+        state["version"], sha, state["candidate_tree_sha"],
+    )
+    release_content_review.require_approved_content(review, state["content_sha"])
+    pr = pr_delivery.wait_for_pr_checks(
+        int(state["pr_number"]), timeout=timeout, poll_interval=poll_interval,
+    )
+    if pr.get("headRefOid") != sha:
+        _fail("PR head 在确认前发生变化；必须重新展示版本内容")
+    if pr.get("baseRefOid") and pr.get("baseRefOid") != state["base_sha"]:
+        _fail("PR 目标 master 在确认前发生变化；必须重新准备并确认")
+    return pr
+
+
+def _dispatch_formal_release(
+    version: str,
+    approved_content_sha: str,
+) -> dict[str, Any]:
+    """Run formal publication from the worktree that actually owns master."""
+    if _git_text("branch", "--show-current") == "master":
+        return release_dispatch.dispatch_release(
+            version,
+            execute=True,
+            authorization=release_dispatch.expected_authorization(version),
+            approved_content_sha=approved_content_sha,
+        )
+    master_worktree = pr_delivery._worktree_for_branch("master")
+    if master_worktree is None:
+        _fail("合并后找不到可用于正式发布的 master 工作区")
+    script = master_worktree / "scripts" / "release_dispatch.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--version", version,
+            "--execute",
+            "--authorization", release_dispatch.expected_authorization(version),
+            "--approved-content-sha", approved_content_sha,
+        ],
+        cwd=master_worktree,
+        check=False,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.returncode != 0:
+        _fail(f"master 工作区正式发布失败（退出码 {result.returncode}）")
+    return {"mode": "published_from_master_worktree", "path": str(master_worktree)}
+
+
+def confirm_release(
+    version: str,
+    authorization: str,
+    *,
+    approved_content_sha: str,
+    timeout: int = pr_delivery.DEFAULT_CHECK_TIMEOUT,
+    poll_interval: int = pr_delivery.DEFAULT_POLL_INTERVAL,
+) -> dict[str, Any]:
+    """Validate candidate approval, merge it, then publish to completion."""
+    version = release_prepare.normalize_version(version)
+    _validate_authorization(
+        authorization, expected_confirm_authorization(version), "正式发布",
+    )
+    state = _read_state()
+    if state.get("version") != version:
+        _fail("待确认状态与目标版本不一致")
+    release_content_review.require_approved_content(state, approved_content_sha)
+    if state.get("phase") == "complete":
+        return state
+    if state.get("phase") == "awaiting_content_approval":
+        pr = _verify_candidate(
+            state, timeout=timeout, poll_interval=poll_interval,
+        )
+        merged = pr_delivery._merge_pr(pr)
+        merge_sha = (merged.get("mergeCommit") or {}).get("oid")
+        if not merge_sha:
+            _fail("候选 PR 合并后缺少提交信息")
+        pr_delivery._run_external(["git", "fetch", "origin"], "拉取 GitHub 合并结果")
+        if _tree_sha(merge_sha) != state["candidate_tree_sha"]:
+            _fail("Squash 合并后的文件树与已确认候选不一致，禁止正式发布")
+        state.update({"phase": "merged_pending_sync", "merge_sha": merge_sha})
+        _write_state(state)
+    if state.get("phase") == "merged_pending_sync":
+        pr_delivery.finalize_delivery(state["candidate_branch"], state["merge_sha"])
+        state["phase"] = "merged"
+        _write_state(state)
+
+    formal_review = release_content_review.review_release_content(
+        version, state["merge_sha"],
+    )
+    result = _dispatch_formal_release(version, formal_review["content_sha"])
+    state.update({"phase": "complete", "formal_release": result})
+    _write_state(state)
+    return state
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="单/多分支一键发布统一入口")
+    parser.add_argument("--version", required=True, help="目标版本，不带 v 前缀")
+    parser.add_argument("--notes-file", type=Path, help="项目外 UTF-8 发布说明")
+    parser.add_argument("--branch", action="append", default=[], help="显式纳入的 codex 分支；可重复")
+    parser.add_argument(
+        "--tested-branch", action="append", default=[],
+        help="多分支 GUI 实测凭证 branch=commit_sha；可重复",
+    )
+    parser.add_argument("--execute", action="store_true", help="准备并推送发布候选 PR")
+    parser.add_argument("--confirm", action="store_true", help="确认候选内容并正式发布")
+    parser.add_argument(
+        "--approved-content-sha", default="",
+        help="候选预览生成并由调用方后台传入的内容凭证",
+    )
+    parser.add_argument("--authorization", default="", help="精确授权文本")
+    parser.add_argument("--timeout", type=int, default=pr_delivery.DEFAULT_CHECK_TIMEOUT)
+    parser.add_argument("--poll-interval", type=int, default=pr_delivery.DEFAULT_POLL_INTERVAL)
+    return parser
+
+
+def main() -> int:
+    release_prepare.build.run_in_venv(__file__)
+    args = _build_parser().parse_args()
+    try:
+        if args.confirm:
+            confirm_release(
+                args.version,
+                args.authorization,
+                approved_content_sha=args.approved_content_sha,
+                timeout=args.timeout,
+                poll_interval=args.poll_interval,
+            )
+        elif args.execute:
+            prepare_candidate(
+                args.version,
+                notes_file=args.notes_file,
+                branches=args.branch,
+                tested_branches=args.tested_branch,
+                authorization=args.authorization,
+                timeout=args.timeout,
+                poll_interval=args.poll_interval,
+            )
+        else:
+            _fail("必须指定 --execute 准备候选，或使用 --confirm 继续正式发布")
+    except (
+        ReleaseFlowError,
+        release_prepare.ReleasePreparationError,
+        release_content_review.ReleaseContentReviewError,
+        pr_delivery.PRDeliveryError,
+        release_dispatch.ReleaseDispatchError,
+        subprocess.CalledProcessError,
+    ) as exc:
+        print(f"\n[失败] {exc}", file=sys.stderr)
+        return 1
+    print("\n[OK] 一键发布流程当前阶段完成")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_release_content_review.py
+++ b/tests/unit/test_release_content_review.py
@@ -65,3 +65,16 @@ def test_approval_rejects_missing_or_stale_digest():
         review.require_approved_content(evidence, "")
     with _raises("必须重新展示并确认"):
         review.require_approved_content(evidence, "d" * 64)
+
+
+def test_candidate_approval_binds_tree_instead_of_pre_merge_commit():
+    with (
+        patch.object(review.build, "_extract_changelog_release", return_value=("v2.24 — Test", "body")),
+        patch.object(review, "audit_user_facing_release", return_value=[]),
+    ):
+        first = review.review_release_candidate("2.24", "a" * 40, "t" * 40)
+        same_tree = review.review_release_candidate("2.24", "b" * 40, "t" * 40)
+        changed_tree = review.review_release_candidate("2.24", "b" * 40, "x" * 40)
+
+    assert first["content_sha"] == same_tree["content_sha"]
+    assert first["content_sha"] != changed_tree["content_sha"]

--- a/tests/unit/test_release_flow.py
+++ b/tests/unit/test_release_flow.py
@@ -1,0 +1,342 @@
+import importlib.util
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import call, patch
+
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "boss_resume_filter_release_flow",
+    BASE_DIR / "scripts" / "release_flow.py",
+)
+assert SPEC and SPEC.loader
+release_flow = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(release_flow)
+
+
+@contextmanager
+def _raises(error_type, message: str):
+    try:
+        yield
+    except error_type as exc:
+        assert message in str(exc)
+    else:
+        raise AssertionError(f"expected {error_type.__name__}: {message}")
+
+
+def _candidate_state():
+    return {
+        "schema": 1,
+        "phase": "awaiting_content_approval",
+        "version": "2.24",
+        "source_branches": ["codex/feature-a"],
+        "tested_branches": {},
+        "candidate_branch": "codex/feature-a",
+        "candidate_sha": "a" * 40,
+        "candidate_tree_sha": "t" * 40,
+        "base_sha": "b" * 40,
+        "pr_number": 42,
+        "pr_url": "https://github.example/pr/42",
+        "release_title": "v2.24 — Test",
+        "release_body": "### 问题修复\n\n- **Test**：Description",
+        "content_sha": "c" * 64,
+    }
+
+
+def test_authorizations_are_exact_and_multi_branch_order_is_explicit():
+    assert release_flow.expected_start_authorization("2.24", ["codex/a"]) == (
+        "一键发布版本 v2.24"
+    )
+    assert release_flow.expected_start_authorization(
+        "2.24", ["codex/a", "codex/b"]
+    ) == "一键发布版本 v2.24，包含 codex/a、codex/b"
+    assert release_flow.expected_confirm_authorization("2.24") == "确认发布 v2.24"
+
+
+def test_multi_branch_gui_evidence_must_match_each_exact_head():
+    branches = ["codex/a", "codex/b"]
+    tested = {"codex/a": "a" * 40, "codex/b": "b" * 40}
+
+    def git_text(*args):
+        if args == ("rev-parse", "codex/a"):
+            return "a" * 40
+        if args == ("rev-parse", "codex/b"):
+            return "x" * 40
+        raise AssertionError(args)
+
+    with (
+        patch.object(release_flow.pr_delivery, "_local_branch_exists", return_value=True),
+        patch.object(release_flow.pr_delivery, "_worktree_for_branch", return_value=Path("D:/branch")),
+        patch.object(release_flow.pr_delivery, "_assert_clean_worktree"),
+        patch.object(release_flow, "_run"),
+        patch.object(release_flow, "_git_text", side_effect=git_text),
+        _raises(release_flow.ReleaseFlowError, "GUI 实测凭证"),
+    ):
+        release_flow._validate_source_branches(branches, tested)
+
+
+def test_multi_branch_tests_run_inside_each_branch_worktree():
+    branch = "codex/a"
+    head = "a" * 40
+    worktree = Path("D:/worktrees/a")
+    with (
+        patch.object(release_flow.pr_delivery, "_local_branch_exists", return_value=True),
+        patch.object(release_flow.pr_delivery, "_worktree_for_branch", return_value=worktree),
+        patch.object(release_flow.pr_delivery, "_assert_clean_worktree") as clean,
+        patch.object(release_flow, "_git_text", return_value=head),
+        patch.object(release_flow, "_run") as run,
+    ):
+        release_flow._validate_source_branches([branch], {branch: head})
+
+    assert run.call_args_list == [
+        call([release_flow.sys.executable, "tests/run_unit_tests.py"], cwd=worktree),
+        call([release_flow.sys.executable, "tests/test_import.py"], cwd=worktree),
+    ]
+    assert clean.call_count == 2
+
+
+def test_existing_aggregate_must_contain_every_declared_source_branch():
+    branches = ["codex/a", "codex/b"]
+    tested = {"codex/a": "a" * 40, "codex/b": "b" * 40}
+    with (
+        patch.object(release_flow, "_validate_source_branches"),
+        patch.object(release_flow.pr_delivery, "_local_branch_exists", return_value=True),
+        patch.object(release_flow, "_git_text", return_value="codex/release-v2.24"),
+        patch.object(
+            release_flow.pr_delivery,
+            "_is_ancestor",
+            side_effect=[True, False],
+        ),
+        _raises(release_flow.ReleaseFlowError, "未完整包含"),
+    ):
+        release_flow._prepare_aggregate_branch(
+            "2.24", branches, tested, "m" * 40,
+        )
+
+
+def test_prepare_candidate_stops_after_pr_checks_and_writes_review_state():
+    gate = {"head_sha": "a" * 40, "master_sha": "b" * 40}
+    pr = {"number": 42, "url": "https://github.example/pr/42"}
+    checked = {**pr, "state": "OPEN"}
+    review = {
+        "release_title": "v2.24 — Test",
+        "release_body": "### 问题修复\n\n- **Test**：Description",
+        "candidate_sha": "a" * 40,
+        "candidate_tree_sha": "t" * 40,
+        "content_sha": "c" * 64,
+        "review_warnings": [],
+    }
+    events = []
+    with (
+        patch.object(release_flow, "_git_text", return_value="codex/feature-a"),
+        patch.object(release_flow, "_validate_notes_file", return_value=Path("D:/notes.md")),
+        patch.object(release_flow, "_assert_clean"),
+        patch.object(release_flow, "_fetch_and_verify_masters", return_value="b" * 40),
+        patch.object(release_flow.release_prepare, "assert_target_tag_available"),
+        patch.object(
+            release_flow,
+            "_prepare_single_branch",
+            side_effect=lambda *_: events.append("branch") or "codex/feature-a",
+        ),
+        patch.object(
+            release_flow,
+            "_apply_release_materials",
+            side_effect=lambda *_: events.append("materials"),
+        ),
+        patch.object(
+            release_flow.pr_delivery,
+            "preflight",
+            side_effect=lambda *_args, **_kwargs: events.append("gate") or gate,
+        ),
+        patch.object(
+            release_flow.pr_delivery,
+            "_push_and_create_pr",
+            side_effect=lambda *_args, **_kwargs: events.append("push_pr") or pr,
+        ),
+        patch.object(
+            release_flow.pr_delivery,
+            "wait_for_pr_checks",
+            side_effect=lambda *_args, **_kwargs: events.append("checks") or checked,
+        ),
+        patch.object(release_flow, "_tree_sha", return_value="t" * 40),
+        patch.object(
+            release_flow.release_content_review,
+            "review_release_candidate",
+            return_value=review,
+        ),
+        patch.object(
+            release_flow,
+            "_write_state",
+            side_effect=lambda *_: events.append("state"),
+        ) as write_state,
+        patch.object(release_flow, "_print_candidate"),
+        patch.object(release_flow.pr_delivery, "_merge_pr") as merge,
+        patch.object(release_flow, "_dispatch_formal_release") as dispatch,
+    ):
+        result = release_flow.prepare_candidate(
+            "2.24",
+            notes_file=Path("D:/notes.md"),
+            branches=[],
+            tested_branches=[],
+            authorization="一键发布版本 v2.24",
+            timeout=30,
+            poll_interval=1,
+        )
+
+    assert events == ["branch", "materials", "gate", "push_pr", "checks", "state"]
+    assert result["phase"] == "awaiting_content_approval"
+    write_state.assert_called_once()
+    merge.assert_not_called()
+    dispatch.assert_not_called()
+
+
+def test_confirm_rejects_changed_candidate_before_merge():
+    state = _candidate_state()
+    with (
+        patch.object(release_flow, "_read_state", return_value=state),
+        patch.object(
+            release_flow,
+            "_git_text",
+            side_effect=["codex/feature-a", "d" * 40],
+        ),
+        patch.object(release_flow, "_assert_clean"),
+        patch.object(release_flow.pr_delivery, "_merge_pr") as merge,
+        _raises(release_flow.ReleaseFlowError, "提交在确认前发生变化"),
+    ):
+        release_flow.confirm_release(
+            "2.24", "确认发布 v2.24", approved_content_sha="c" * 64,
+        )
+    merge.assert_not_called()
+
+
+def test_confirm_rejects_stale_preview_digest_before_candidate_checks():
+    state = _candidate_state()
+    with (
+        patch.object(release_flow, "_read_state", return_value=state),
+        patch.object(release_flow, "_verify_candidate") as verify,
+        _raises(release_flow.release_content_review.ReleaseContentReviewError, "必须重新展示并确认"),
+    ):
+        release_flow.confirm_release(
+            "2.24", "确认发布 v2.24", approved_content_sha="d" * 64,
+        )
+    verify.assert_not_called()
+
+
+def test_confirm_verifies_tree_then_merges_syncs_and_publishes():
+    state = _candidate_state()
+    pr = {
+        "number": 42,
+        "state": "OPEN",
+        "headRefOid": "a" * 40,
+        "baseRefOid": "b" * 40,
+    }
+    merged = {"mergeCommit": {"oid": "m" * 40}}
+    events = []
+    with (
+        patch.object(release_flow, "_read_state", return_value=state),
+        patch.object(release_flow, "_verify_candidate", return_value=pr),
+        patch.object(
+            release_flow.pr_delivery,
+            "_merge_pr",
+            side_effect=lambda *_: events.append("merge") or merged,
+        ),
+        patch.object(
+            release_flow.pr_delivery,
+            "_run_external",
+            side_effect=lambda *_args, **_kwargs: events.append("fetch"),
+        ),
+        patch.object(release_flow, "_tree_sha", return_value="t" * 40),
+        patch.object(
+            release_flow.pr_delivery,
+            "finalize_delivery",
+            side_effect=lambda *_: events.append("sync"),
+        ),
+        patch.object(
+            release_flow,
+            "_write_state",
+            side_effect=lambda *_: events.append("state"),
+        ),
+        patch.object(
+            release_flow.release_content_review,
+            "review_release_content",
+            return_value={"content_sha": "f" * 64},
+        ),
+        patch.object(
+            release_flow,
+            "_dispatch_formal_release",
+            side_effect=lambda *_: events.append("publish") or {"mode": "published"},
+        ),
+    ):
+        result = release_flow.confirm_release(
+            "2.24", "确认发布 v2.24", approved_content_sha="c" * 64,
+        )
+
+    assert events == ["merge", "fetch", "state", "sync", "state", "publish", "state"]
+    assert result["phase"] == "complete"
+
+
+def test_confirm_stops_if_squash_tree_differs_from_approved_candidate():
+    state = _candidate_state()
+    pr = {"number": 42, "state": "OPEN"}
+    merged = {"mergeCommit": {"oid": "m" * 40}}
+    with (
+        patch.object(release_flow, "_read_state", return_value=state),
+        patch.object(release_flow, "_verify_candidate", return_value=pr),
+        patch.object(release_flow.pr_delivery, "_merge_pr", return_value=merged),
+        patch.object(release_flow.pr_delivery, "_run_external"),
+        patch.object(release_flow, "_tree_sha", return_value="x" * 40),
+        patch.object(release_flow.pr_delivery, "finalize_delivery") as finalize,
+        patch.object(release_flow, "_dispatch_formal_release") as dispatch,
+        _raises(release_flow.ReleaseFlowError, "文件树与已确认候选不一致"),
+    ):
+        release_flow.confirm_release(
+            "2.24", "确认发布 v2.24", approved_content_sha="c" * 64,
+        )
+
+    finalize.assert_not_called()
+    dispatch.assert_not_called()
+
+
+def test_confirm_resumes_sync_after_merge_without_remerging_pr():
+    state = {
+        **_candidate_state(),
+        "phase": "merged_pending_sync",
+        "merge_sha": "m" * 40,
+    }
+    with (
+        patch.object(release_flow, "_read_state", return_value=state),
+        patch.object(release_flow.pr_delivery, "_merge_pr") as merge,
+        patch.object(release_flow.pr_delivery, "finalize_delivery") as finalize,
+        patch.object(release_flow, "_write_state"),
+        patch.object(
+            release_flow.release_content_review,
+            "review_release_content",
+            return_value={"content_sha": "f" * 64},
+        ),
+        patch.object(
+            release_flow,
+            "_dispatch_formal_release",
+            return_value={"mode": "published"},
+        ),
+    ):
+        release_flow.confirm_release(
+            "2.24", "确认发布 v2.24", approved_content_sha="c" * 64,
+        )
+
+    merge.assert_not_called()
+    finalize.assert_called_once_with("codex/feature-a", "m" * 40)
+
+
+def test_formal_release_uses_master_worktree_when_current_is_detached():
+    master = Path("D:/master")
+    completed = subprocess.CompletedProcess([], 0, "", "")
+    with (
+        patch.object(release_flow, "_git_text", return_value=""),
+        patch.object(release_flow.pr_delivery, "_worktree_for_branch", return_value=master),
+        patch.object(release_flow.subprocess, "run", return_value=completed) as run,
+    ):
+        result = release_flow._dispatch_formal_release("2.24", "c" * 64)
+
+    assert result["mode"] == "published_from_master_worktree"
+    assert run.call_args.kwargs["cwd"] == master


### PR DESCRIPTION
## 变更提交

- feat(release): 增加单多分支一键发布流程

## 自动验证

- 稳定单元回归
- 导入烟测
- `git diff --check`
- PR Checks（合并前等待通过）
