### PR TITLE
限制 PR 交付网络等待并输出耗时

### DIFF
--- a/scripts/pr_delivery.py
+++ b/scripts/pr_delivery.py
@@ -36,6 +36,9 @@ subprocess = hidden_subprocess(subprocess)
 DEFAULT_CHECK_TIMEOUT = 30 * 60
 DEFAULT_POLL_INTERVAL = 10
 DEFAULT_CHECK_STARTUP_TIMEOUT = 90
+REMOTE_READ_TIMEOUT_SECONDS = 30
+GITHUB_WRITE_TIMEOUT_SECONDS = 60
+REMOTE_WRITE_TIMEOUT_SECONDS = 120
 SUCCESS_CONCLUSIONS = {"SUCCESS", "NEUTRAL", "SKIPPED"}
 FAILURE_CONCLUSIONS = {
     "ACTION_REQUIRED",
@@ -51,8 +54,29 @@ class PRDeliveryError(RuntimeError):
     """A deterministic PR delivery contract was not satisfied."""
 
 
+def _configure_output_streams() -> None:
+    """Keep Chinese diagnostics readable and delivery progress immediately visible."""
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(
+                encoding="utf-8",
+                errors="replace",
+                line_buffering=True,
+                write_through=True,
+            )
+
+
 def _fail(message: str) -> None:
     raise PRDeliveryError(message)
+
+
+def _stream_text(value: str | bytes | None) -> str:
+    """Normalize subprocess timeout output to text."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
 
 
 def _run(
@@ -61,16 +85,38 @@ def _run(
     cwd: Path | None = None,
     check: bool = True,
     capture_output: bool = False,
+    timeout: float | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        args,
-        cwd=cwd or BASE_DIR,
-        check=check,
-        capture_output=capture_output,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-    )
+    try:
+        return subprocess.run(
+            args,
+            cwd=cwd or BASE_DIR,
+            check=check,
+            capture_output=capture_output,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = _stream_text(exc.stdout)
+        stderr = _stream_text(exc.stderr).rstrip()
+        timeout_text = f"command timed out after {float(timeout or 0):g}s"
+        stderr = f"{stderr}\n{timeout_text}".strip()
+        result = subprocess.CompletedProcess(
+            args,
+            124,
+            stdout=stdout,
+            stderr=stderr,
+        )
+        if check:
+            raise subprocess.CalledProcessError(
+                result.returncode,
+                args,
+                output=result.stdout,
+                stderr=result.stderr,
+            ) from exc
+        return result
 
 
 def _git_text(*args: str, cwd: Path | None = None) -> str:
@@ -84,9 +130,27 @@ def _run_external(
     *,
     postcondition: Callable[[], bool] | None = None,
     cwd: Path | None = None,
+    timeout: float = REMOTE_WRITE_TIMEOUT_SECONDS,
 ) -> subprocess.CompletedProcess[str]:
+    attempt = 0
+
+    def run_attempt(
+        command: list[str],
+        **kwargs: Any,
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal attempt
+        attempt += 1
+        return _run_remote_attempt(
+            command,
+            label,
+            attempt=attempt,
+            timeout=timeout,
+            cwd=cwd,
+            **kwargs,
+        )
+
     result = release_retry.run_cli_with_retries(
-        lambda command, **kwargs: _run(command, cwd=cwd, **kwargs),
+        run_attempt,
         args,
         label,
         postcondition=postcondition,
@@ -94,6 +158,61 @@ def _run_external(
     if result.returncode != 0:
         _fail(f"{label}失败：{release_retry.command_detail(result)}")
     return result
+
+
+def _run_remote_attempt(
+    args: list[str],
+    label: str,
+    *,
+    attempt: int,
+    timeout: float,
+    cwd: Path | None = None,
+    **kwargs: Any,
+) -> subprocess.CompletedProcess[str]:
+    """Run one bounded remote attempt and report its elapsed time."""
+    print(
+        f"  [执行] {label}（第 {attempt} 次，单次超时 {timeout:g}s）",
+        flush=True,
+    )
+    started = time.perf_counter()
+    result = _run(
+        args,
+        cwd=cwd,
+        timeout=timeout,
+        **kwargs,
+    )
+    elapsed = time.perf_counter() - started
+    outcome = "成功" if result.returncode == 0 else f"失败({result.returncode})"
+    print(
+        f"  [耗时] {label}（第 {attempt} 次）{elapsed:.2f}s，{outcome}",
+        flush=True,
+    )
+    return result
+
+
+def _run_remote_json_query(args: list[str], label: str) -> Any:
+    """Run one retryable JSON query with a bounded per-attempt timeout."""
+    attempt = 0
+
+    def run_attempt(
+        command: list[str],
+        **kwargs: Any,
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal attempt
+        attempt += 1
+        return _run_remote_attempt(
+            command,
+            label,
+            attempt=attempt,
+            timeout=REMOTE_READ_TIMEOUT_SECONDS,
+            **kwargs,
+        )
+
+    return release_retry.run_json_query_with_retries(
+        run_attempt,
+        args,
+        label,
+    )
 
 
 def expected_authorization(branch: str) -> str:
@@ -132,6 +251,7 @@ def _remote_ref(remote: str, ref: str) -> str:
     output = _run_external(
         ["git", "ls-remote", remote, ref],
         f"读取 {remote}/{ref}",
+        timeout=REMOTE_READ_TIMEOUT_SECONDS,
     ).stdout.strip()
     if not output:
         return ""
@@ -229,6 +349,7 @@ def preflight(branch: str, *, run_tests: bool = True) -> dict[str, str]:
     _run_external(
         ["gh", "auth", "status", "--hostname", "github.com"],
         "检查 GitHub 登录状态",
+        timeout=REMOTE_READ_TIMEOUT_SECONDS,
     )
     _run_external(["git", "fetch", "origin"], "拉取 GitHub 更新")
     _run_external(["git", "fetch", "gitee"], "拉取 Gitee 更新")
@@ -263,8 +384,7 @@ def preflight(branch: str, *, run_tests: bool = True) -> dict[str, str]:
 
 def _find_delivery_pr(branch: str, head_sha: str) -> dict[str, Any] | None:
     try:
-        candidates = release_retry.run_json_query_with_retries(
-            _run,
+        candidates = _run_remote_json_query(
             [
             "gh", "pr", "list",
             "--head", branch,
@@ -359,6 +479,7 @@ def _sync_open_pr_metadata(
                 body,
             ],
             f"刷新 PR #{number} 标题和正文",
+            timeout=GITHUB_WRITE_TIMEOUT_SECONDS,
         )
         print(f"  [更新] PR #{number} 标题和正文已按当前分支刷新")
     else:
@@ -413,8 +534,11 @@ def _push_and_create_pr(
     create_result: subprocess.CompletedProcess[str] | None = None
     total_attempts = len(release_retry.RETRY_DELAYS) + 1
     for attempt in range(1, total_attempts + 1):
-        create_result = _run(
+        create_result = _run_remote_attempt(
             create_args,
+            "创建交付 PR",
+            attempt=attempt,
+            timeout=GITHUB_WRITE_TIMEOUT_SECONDS,
             check=False,
             capture_output=True,
         )
@@ -453,8 +577,7 @@ def _push_and_create_pr(
 
 def _pr_view(number: int) -> dict[str, Any]:
     try:
-        data = release_retry.run_json_query_with_retries(
-            _run,
+        data = _run_remote_json_query(
             [
             "gh", "pr", "view", str(number),
             "--json",
@@ -505,8 +628,7 @@ def _pull_request_run_state_for_head(
     if not branch or not head_sha:
         return None
     try:
-        runs = release_retry.run_json_query_with_retries(
-            _run,
+        runs = _run_remote_json_query(
             [
                 "gh", "run", "list",
                 "--branch", branch,
@@ -629,6 +751,7 @@ def _merge_pr(pr: dict[str, Any]) -> dict[str, Any]:
             ["gh", "pr", "merge", str(number), "--squash"],
             f"合并 PR #{number}",
             postcondition=lambda: _pr_view(number).get("state") == "MERGED",
+            timeout=GITHUB_WRITE_TIMEOUT_SECONDS,
         )
         current = _pr_view(number)
     if current.get("state") != "MERGED":
@@ -776,9 +899,7 @@ def deliver(
 
 
 def main(argv: list[str] | None = None) -> int:
-    for stream in (sys.stdout, sys.stderr):
-        if hasattr(stream, "reconfigure"):
-            stream.reconfigure(encoding="utf-8", errors="replace")
+    _configure_output_streams()
     parser = argparse.ArgumentParser(description="普通 PR 一次授权交付")
     parser.add_argument("--branch", help="codex/<task>；默认使用当前分支")
     parser.add_argument("--title", help="新建 PR 时使用的标题；默认取最新提交标题")

--- a/tests/unit/test_pr_delivery.py
+++ b/tests/unit/test_pr_delivery.py
@@ -1,6 +1,7 @@
 import importlib.util
 import subprocess
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stdout
+from io import StringIO
 from pathlib import Path
 from unittest.mock import Mock, call, patch
 
@@ -41,6 +42,65 @@ def test_delivery_rejects_master_and_invalid_topic_branches():
     for branch in ("master", "feature/test", "codex/../master", "codex/"):
         with _raises(pr_delivery.PRDeliveryError, "分支"):
             pr_delivery.validate_branch_name(branch)
+
+
+def test_remote_command_timeout_becomes_retryable_completed_process():
+    command = ["gh", "pr", "view", "61"]
+    timeout = subprocess.TimeoutExpired(command, 30)
+    with patch.object(pr_delivery.subprocess, "run", side_effect=timeout):
+        result = pr_delivery._run(
+            command,
+            check=False,
+            capture_output=True,
+            timeout=30,
+        )
+
+    assert result.returncode == 124
+    assert "timed out after 30s" in result.stderr
+    assert pr_delivery.release_retry.is_retryable_cli_failure(result)
+
+
+def test_remote_json_query_uses_read_timeout_and_reports_attempt_duration():
+    output = StringIO()
+    with (
+        patch.object(
+            pr_delivery,
+            "_run",
+            return_value=_completed('{"state":"OPEN"}'),
+        ) as run,
+        patch.object(pr_delivery.time, "perf_counter", side_effect=[10.0, 11.25]),
+        redirect_stdout(output),
+    ):
+        result = pr_delivery._run_remote_json_query(
+            ["gh", "pr", "view", "61"],
+            "读取 PR #61 状态",
+        )
+
+    assert result == {"state": "OPEN"}
+    assert run.call_args.kwargs["timeout"] == (
+        pr_delivery.REMOTE_READ_TIMEOUT_SECONDS
+    )
+    assert "读取 PR #61 状态（第 1 次" in output.getvalue()
+    assert "1.25s" in output.getvalue()
+
+
+def test_output_streams_are_line_buffered_for_live_delivery_progress():
+    stdout = Mock()
+    stderr = Mock()
+    with (
+        patch.object(pr_delivery.sys, "stdout", stdout),
+        patch.object(pr_delivery.sys, "stderr", stderr),
+    ):
+        pr_delivery._configure_output_streams()
+
+    expected = {
+        "encoding": "utf-8",
+        "errors": "replace",
+        "line_buffering": True,
+        "write_through": True,
+    }
+    stdout.reconfigure.assert_called_once_with(**expected)
+    stderr.reconfigure.assert_called_once_with(**expected)
 
 
 def test_check_rollup_distinguishes_pending_success_and_failure():
@@ -570,7 +630,7 @@ def test_pr_creation_retries_transient_new_branch_propagation_failure():
         _completed("https://github.example/pr/10\n"),
     ]
     with (
-        patch.object(pr_delivery, "_run", side_effect=run_results),
+        patch.object(pr_delivery, "_run", side_effect=run_results) as run,
         patch.object(pr_delivery, "_find_delivery_pr", side_effect=[None, None, pr]),
         patch.object(pr_delivery, "_default_pr_title", return_value="Title"),
         patch.object(pr_delivery, "_default_pr_body", return_value="Body"),
@@ -580,6 +640,15 @@ def test_pr_creation_retries_transient_new_branch_propagation_failure():
 
     assert result == pr
     sleep.assert_called_once_with(2)
+    assert run.call_args_list[0].kwargs["timeout"] == (
+        pr_delivery.REMOTE_WRITE_TIMEOUT_SECONDS
+    )
+    assert run.call_args_list[1].kwargs["timeout"] == (
+        pr_delivery.GITHUB_WRITE_TIMEOUT_SECONDS
+    )
+    assert run.call_args_list[2].kwargs["timeout"] == (
+        pr_delivery.GITHUB_WRITE_TIMEOUT_SECONDS
+    )
 
 
 def test_existing_open_pr_is_reused_even_when_head_ref_is_stale():


### PR DESCRIPTION
## 变更提交

- 限制 PR 交付网络等待并输出耗时

## 自动验证

- 稳定单元回归
- 导入烟测
- `git diff --check`
- PR Checks（合并前等待通过）
