### PR TITLE
fix(scroll): 修复 Apple Silicon 上滚动导致的进程崩溃 (SIGABRT)

### DIFF
--- a/gui_scroll_support.py
+++ b/gui_scroll_support.py
@@ -9,6 +9,38 @@ from typing import Any, Protocol
 from gui_app_shell import PageIndex
 
 
+def resolve_msg_send_double(objc: Any) -> Any:
+    """Return a 2-argument objc_msgSend that yields a C double.
+
+    arm64 has no ``objc_msgSend_fpret`` (doubles come back in the normal return
+    register), so Apple Silicon always takes the fallback branch. The fallback
+    must be built from ``objc_msgSend``'s *address*: handing ``CFUNCTYPE`` the
+    ``_FuncPtr`` object itself makes ctypes wrap it as a Python callback that
+    re-enters ``objc_msgSend`` under its 3-argument ``argtypes``, raising
+    ``TypeError`` on every scroll event. That error surfaces across a ctypes
+    callback boundary, so the caller's ``except`` clause never sees it, and the
+    repeated failures eventually abort the interpreter with
+    ``PyEval_RestoreThread: the GIL is released``.
+
+    Returns None when the symbol address cannot be resolved.
+    """
+    import ctypes
+
+    try:
+        objc.objc_msgSend_fpret.restype = ctypes.c_double
+        objc.objc_msgSend_fpret.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        return objc.objc_msgSend_fpret
+    except AttributeError:
+        address = ctypes.cast(objc.objc_msgSend, ctypes.c_void_p).value
+        if not address:
+            return None
+        return ctypes.CFUNCTYPE(
+            ctypes.c_double,
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+        )(address)
+
+
 class ScrollSupportHost(Protocol):
     """Explicit GUI surface used by cross-platform scroll routing."""
 
@@ -235,19 +267,9 @@ class ScrollSupport:
                 self.host.root.after(1000, self.setup_cocoa_scroll_hook)
                 return
 
-            try:
-                objc.objc_msgSend_fpret.restype = ctypes.c_double
-                objc.objc_msgSend_fpret.argtypes = [
-                    ctypes.c_void_p,
-                    ctypes.c_void_p,
-                ]
-                msg_send_double = objc.objc_msgSend_fpret
-            except AttributeError:
-                msg_send_double = ctypes.CFUNCTYPE(
-                    ctypes.c_double,
-                    ctypes.c_void_p,
-                    ctypes.c_void_p,
-                )(objc.objc_msgSend)
+            msg_send_double = resolve_msg_send_double(objc)
+            if msg_send_double is None:
+                return
             msg_send_is_kind = ctypes.CFUNCTYPE(
                 ctypes.c_bool,
                 ctypes.c_void_p,

--- a/tests/unit/test_gui_scroll_support.py
+++ b/tests/unit/test_gui_scroll_support.py
@@ -1,0 +1,87 @@
+import ctypes
+from typing import Any
+
+from gui_scroll_support import resolve_msg_send_double
+
+
+def _three_arg_msg_send() -> Any:
+    """Stand in for objc_msgSend as gui_scroll_support configures it.
+
+    setup_cocoa_scroll_hook sets objc_msgSend.argtypes to three void pointers
+    for the superview/isKindOfClass walk, which is exactly the state the double
+    accessor has to cope with.
+    """
+    prototype = ctypes.CFUNCTYPE(
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+    )
+    msg_send = prototype(lambda _self, _sel, _arg: 0)
+    msg_send.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
+    return msg_send
+
+
+class _AppleSiliconObjc:
+    """libobjc as seen on arm64, where objc_msgSend_fpret does not exist."""
+
+    def __init__(self) -> None:
+        self.objc_msgSend = _three_arg_msg_send()
+
+    def __getattr__(self, name: str):
+        # ctypes raises AttributeError for symbols missing from the library;
+        # objc_msgSend_fpret is x86_64-only, so arm64 must hit the fallback.
+        raise AttributeError(f"dlsym: symbol not found: {name}")
+
+
+class _IntelObjc:
+    """libobjc as seen on x86_64, where objc_msgSend_fpret is available."""
+
+    def __init__(self) -> None:
+        self.objc_msgSend = _three_arg_msg_send()
+        self.objc_msgSend_fpret = _three_arg_msg_send()
+
+
+def test_arm64_fallback_targets_objc_msgsend_itself_not_a_python_callback():
+    objc = _AppleSiliconObjc()
+
+    resolved = resolve_msg_send_double(objc)
+
+    # Passing the _FuncPtr object to CFUNCTYPE would wrap it in a fresh Python
+    # callback trampoline at a different address; that trampoline re-enters
+    # objc_msgSend under its three-argument argtypes and raises TypeError on
+    # every scroll event, across a callback boundary where the caller's except
+    # clause cannot catch it. Building from the address keeps a plain pointer.
+    assert (
+        ctypes.cast(resolved, ctypes.c_void_p).value
+        == ctypes.cast(objc.objc_msgSend, ctypes.c_void_p).value
+    )
+
+
+def test_arm64_fallback_accepts_two_arguments():
+    objc = _AppleSiliconObjc()
+
+    resolved = resolve_msg_send_double(objc)
+
+    assert tuple(resolved.argtypes) == (ctypes.c_void_p, ctypes.c_void_p)
+    assert resolved.restype is ctypes.c_double
+
+
+def test_intel_path_uses_fpret_with_double_return():
+    objc = _IntelObjc()
+
+    resolved = resolve_msg_send_double(objc)
+
+    assert resolved is objc.objc_msgSend_fpret
+    assert resolved.restype is ctypes.c_double
+    assert tuple(resolved.argtypes) == (ctypes.c_void_p, ctypes.c_void_p)
+
+
+def test_missing_msg_send_address_degrades_instead_of_raising():
+    class _NullObjc:
+        objc_msgSend = ctypes.c_void_p(None)
+
+        def __getattr__(self, name: str):
+            raise AttributeError(f"dlsym: symbol not found: {name}")
+
+    assert resolve_msg_send_double(_NullObjc()) is None


### PR DESCRIPTION
## 问题

在 Apple Silicon Mac 上源码启动 GUI 后，用触控板或鼠标滚轮滚动任意页面，进程会以 SIGABRT 崩溃。

崩溃前 stderr 会刷屏：

```
Exception ignored on calling ctypes callback function <_FuncPtr object at 0x...>:
Traceback (most recent call last):
  File "gui_scroll_support.py", line 278, in cocoa_scroll_impl
    delta_y = msg_send_double(event, sel_delta_y)
TypeError: this function takes at least 3 arguments (2 given)
```

随后：

```
Fatal Python error: PyEval_RestoreThread: the function must be called with the GIL
held, after Python initialization and before Python finalization, but the GIL is
released (the current Python thread state is NULL)
```

## 原因

`objc_msgSend_fpret` 只存在于 x86_64；arm64 上浮点返回值走普通返回寄存器，没有这个符号：

```
dlsym(0x..., objc_msgSend_fpret): symbol not found
```

所以 Apple Silicon **必然**走 `except AttributeError` 的 fallback 分支。而 fallback 写的是：

```python
msg_send_double = ctypes.CFUNCTYPE(
    ctypes.c_double, ctypes.c_void_p, ctypes.c_void_p,
)(objc.objc_msgSend)          # ← 传的是 _FuncPtr 对象
```

`CFUNCTYPE(...)` 收到 `_FuncPtr` 时，会把它当成 **Python 可调用对象**、另建一个回调蹦床，而不是当成函数指针复用其地址。该蹦床反过来调用 `objc.objc_msgSend`——但它的 `argtypes` 已经在同一个函数里（`setup_cocoa_scroll_hook` 中 superview / isKindOfClass 那段）被设成三个 `c_void_p`，于是每个滚轮事件都抛 `TypeError`。

关键在于这个异常发生在 **ctypes 回调边界内部**，`cocoa_scroll_impl` 外层的 `except Exception: pass` 接不到，只会走 "Exception ignored" 路径。高频滚轮事件持续在回调里抛异常，最终线程状态错乱，解释器 abort。

## 修改

从 `objc_msgSend` 的**地址**构造函数指针，得到真正的 2 参数外部函数而非嵌套回调：

```python
address = ctypes.cast(objc.objc_msgSend, ctypes.c_void_p).value
if not address:
    return None
return ctypes.CFUNCTYPE(ctypes.c_double, ctypes.c_void_p, ctypes.c_void_p)(address)
```

同时把这段提取为模块级 `resolve_msg_send_double()`，便于回归覆盖。地址取不到时返回 `None`，`setup_cocoa_scroll_hook` 直接返回，保持 AGENTS.md 要求的「Cocoa hook 失败只做静默降级、不影响非 macOS 启动」。

x86_64 的 `objc_msgSend_fpret` 分支行为不变。

## 验证

真机验证修复后的取值路径正确（`NSNumber numberWithDouble:1.5` → `doubleValue` 返回 `1.5`），修复前后滚动行为一致且不再崩溃。

新增 `tests/unit/test_gui_scroll_support.py`（4 个用例），不依赖 libobjc、跨平台可跑。核心断言是「fallback 得到的指针地址必须与 `objc_msgSend` 相同」——修复前地址不同（新建蹦床）故断言失败，修复后通过。

```
python tests/run_unit_tests.py
SUMMARY total=1799 failures=0 elapsed=2.17s
```

## 环境

macOS 26.5 / Apple Silicon / Python 3.13.9 / Tk 9.0 / 源码运行 v2.28.1